### PR TITLE
Tidied up GUI of ShowFlagsPanel (property filters)

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/GroupEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/GroupEditor.java
@@ -19,6 +19,7 @@
 //               INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
 package org.micromanager.internal.dialogs;
 
+import java.awt.Dimension;
 import java.util.ArrayList;
 import java.util.Arrays;
 import javax.swing.JCheckBox;
@@ -45,7 +46,7 @@ public final class GroupEditor extends ConfigDialog {
 
    public GroupEditor(String groupName, String presetName, Studio gui, CMMCore core, boolean newItem) {
       super(groupName, presetName, gui, core, newItem);
-      instructionsText_ = "Here you can specify the properties included\nin a configuration group.";
+      instructionsText_ = "Specify properties in this configuration group:";
       nameFieldLabelText_ = "Group name:";
       initName_ = groupName_;
       title_ = "Group Editor";
@@ -58,8 +59,9 @@ public final class GroupEditor extends ConfigDialog {
               propertyUsedColumn(1).groupOnly(false).allowChangingProperties(false).allowChangesOnlyWhenUsed(false).isPixelSizeConfig(false).build();
       initializeData();
       data_.setColumnNames("Property Name", "Use in Group?", "Current Property Value");
-      showShowReadonlyCheckBox_ = true;
       initialize();
+      super.loadAndRestorePosition(100, 100, 550, 600);
+      super.setMinimumSize(new Dimension(520, 400));
    }
 
    @Override

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/PixelPresetEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/PixelPresetEditor.java
@@ -20,18 +20,10 @@
 
 package org.micromanager.internal.dialogs;
 
-import java.awt.Font;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
+import java.awt.Dimension;
 import java.awt.geom.AffineTransform;
 import java.text.ParseException;
-import javax.swing.JButton;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JTextArea;
-import javax.swing.JTextField;
 import mmcorej.DoubleVector;
-import net.miginfocom.swing.MigLayout;
 import org.micromanager.Studio;
 import org.micromanager.internal.MMStudio;
 import org.micromanager.internal.utils.AffineUtils;
@@ -48,9 +40,6 @@ public class PixelPresetEditor extends ConfigDialog implements PixelSizeProvider
 
    private static final long serialVersionUID = -3709174019188065514L;
 
-   protected final String pixelSizeLabelText_;
-   protected JTextField pixelSizeField_;
-   protected String pixelSize_;
    private DoubleVector affineTransform_;
    private final AffineEditorPanel affineEditorPanel_;
    private final CalibrationListDlg parent_;
@@ -62,10 +51,10 @@ public class PixelPresetEditor extends ConfigDialog implements PixelSizeProvider
       // note: pixelSizeConfigName is called presetName_ in ConfigDialog
       instructionsText_ = "Specify pixel size configuration";
       nameFieldLabelText_ = "Pixel Config Name:";
-      pixelSizeLabelText_ = "Pixel Size (um)";
+      showPixelSize_ = true;
       pixelSize_ = pixelSize;
       initName_ = pixelSizeConfigName;
-      title_ = "Pixel Config Editor";
+      title_ = "Pixel Preset Editor";
       showUnused_ = true;
       showFlagsPanelVisible_ = false;
       scrollPaneTop_ = 140;
@@ -87,12 +76,12 @@ public class PixelPresetEditor extends ConfigDialog implements PixelSizeProvider
       data_.setShowReadOnly(true);
       super.initializeData();
       data_.setColumnNames("Property Name", "Use in Group?", "Current Property Value");
-      showShowReadonlyCheckBox_ = true;
       parent_ = parent;
       affineEditorPanel_ = new AffineEditorPanel(parent_.getStudio(), this, affineTransform_);
 
-      super.initialize();  // will cal out initializeWidgets, which overrides the base class
-
+      super.initialize();  // will call initializeWidgets, which overrides the base class
+      super.loadAndRestorePosition(100, 100, 450, 400);
+      super.setMinimumSize(new Dimension(380, 350));
    }
 
    @Override
@@ -165,64 +154,12 @@ public class PixelPresetEditor extends ConfigDialog implements PixelSizeProvider
    
    @Override
     protected void initializeWidgets() {
-      JPanel leftPanel = new JPanel(
-            new MigLayout("filly, flowy, insets 0 6 0 0, gap 2"));
-      instructionsTextArea_ = new JTextArea();
-      instructionsTextArea_.setFont(new Font("Arial", Font.PLAIN, 12));
-      instructionsTextArea_.setWrapStyleWord(true);
-      instructionsTextArea_.setText(instructionsText_);
-      instructionsTextArea_.setEditable(false);
-      instructionsTextArea_.setOpaque(false);
-      leftPanel.add(instructionsTextArea_, "gaptop 2, gapbottom push");
-
-      final Font boldArial = new Font("Arial", Font.BOLD, 12);
-      nameFieldLabel_ = new JLabel(nameFieldLabelText_);
-      nameFieldLabel_.setFont(boldArial);
-      leftPanel.add(nameFieldLabel_, "split 2, flowx, alignx right");
-
-      nameField_ = new JTextField();
-      nameField_.setText(presetName_);
-      nameField_.setEditable(true);
-      nameField_.setSelectionStart(0);
-      nameField_.setSelectionEnd(nameField_.getText().length());
-      leftPanel.add(nameField_, "width 90!");
-      
-      JLabel pixelSizeFieldLabel = new JLabel(pixelSizeLabelText_);
-      pixelSizeFieldLabel.setFont(boldArial);
-      leftPanel.add(pixelSizeFieldLabel, "split 2, flowx, alignx right");
-      
-      pixelSizeField_ = new JTextField();
-      pixelSizeField_.setText(pixelSize_);
-      pixelSizeField_.setEditable(true);
-      pixelSizeField_.setSelectionStart(0);
-      pixelSizeField_.setSelectionEnd(pixelSizeField_.getText().length());
-      leftPanel.add(pixelSizeField_, "width 90!");
-              
-      add(leftPanel, "growy, gapright push");
-
-      okButton_ = new JButton("OK");
-      okButton_.addActionListener(new ActionListener() {
-         @Override
-         public void actionPerformed(ActionEvent e) {
-            if (table_.isEditing() && table_.getCellEditor() != null) {
-               table_.getCellEditor().stopCellEditing();
-            }
-            okChosen();
-         }
-      });
-      add(okButton_, "gapleft push, split 2, flowy, width 90!");
-
-      cancelButton_ = new JButton("Cancel");
-      cancelButton_.addActionListener(new ActionListener() {
-         @Override
-         public void actionPerformed(ActionEvent e) {
-            dispose();
-         }
-      });
-      add(cancelButton_, "gapleft push, gapbottom push, wrap, width 90!");
-
-      add(affineEditorPanel_, "span 4, growx, center, wrap");
-      
+      super.initializeWidgets();
+   }
+   
+   @Override protected void initializeBetweenWidgetsAndTable() {
+      numRowsBeforeFilters_++;
+      add(affineEditorPanel_, "growx, center");
    }
 
    @Override

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/PresetEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/PresetEditor.java
@@ -21,6 +21,7 @@
 package org.micromanager.internal.dialogs;
 
 
+import java.awt.Dimension;
 import mmcorej.CMMCore;
 import mmcorej.Configuration;
 import mmcorej.StrVector;
@@ -36,7 +37,7 @@ public final class PresetEditor extends ConfigDialog {
 
    public PresetEditor(String groupName, String presetName, Studio gui, CMMCore core, boolean newItem) {
       super(groupName, presetName, gui, core, newItem);
-      instructionsText_ = "Here you can specifiy the property values\nin a configuration preset.";
+      instructionsText_ = "Specify property values for this preset:";
       nameFieldLabelText_ = "Preset name:";
       initName_ = presetName_;
       title_ = "Preset editor for the \"" + groupName + "\" configuration group";
@@ -51,7 +52,8 @@ public final class PresetEditor extends ConfigDialog {
       data_.setColumnNames("Property Name","Preset Value","");
       data_.setShowReadOnly(true);
       initialize();
-
+      super.loadAndRestorePosition(100, 100, 420, 300);
+      super.setMinimumSize(new Dimension(400, 250));
    }
 
    @Override

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/ShowFlags.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/ShowFlags.java
@@ -33,6 +33,7 @@ public final class ShowFlags {
    public boolean stages_ = true;
    public boolean state_ = true;
    public boolean other_ = true;
+   public boolean readonly_ = true;
    public String searchFilter_ = "";
    
    private final Studio studio_;
@@ -42,7 +43,12 @@ public final class ShowFlags {
    private static final String SHOW_STAGES = "show_stages";
    private static final String SHOW_STATE = "show_state";
    private static final String SHOW_OTHER = "show_other";
+   private static final String SHOW_READONLY = "show_readonly";
    private static final String SEARCH_FILTER = "search_filter";
+
+   // TODO consider requiring class at construction
+   // then no need to remember which class it is associated with (can't change during use)
+   //   but also wouldn't be flexible to change class on the fly (would there ever be a need?)
    
    public ShowFlags(Studio studio) {
       studio_ = studio;
@@ -55,6 +61,7 @@ public final class ShowFlags {
       stages_ = profile.getSettings(c).getBoolean(SHOW_STAGES, stages_);
       state_ = profile.getSettings(c).getBoolean(SHOW_STATE, state_);
       other_ = profile.getSettings(c).getBoolean(SHOW_OTHER, other_);
+      readonly_ = profile.getSettings(c).getBoolean(SHOW_READONLY, readonly_);
       searchFilter_ = profile.getSettings(c).getString(SEARCH_FILTER, searchFilter_);
    }
 
@@ -65,6 +72,7 @@ public final class ShowFlags {
       profile.getSettings(c).putBoolean(SHOW_STAGES, stages_);
       profile.getSettings(c).putBoolean(SHOW_STATE, state_);
       profile.getSettings(c).putBoolean(SHOW_OTHER, other_);
+      profile.getSettings(c).putBoolean(SHOW_READONLY, readonly_);
       profile.getSettings(c).putString(SEARCH_FILTER, searchFilter_);
    }
 }


### PR DESCRIPTION
Tidied up GUI of ShowFlagsPanel (property filters) including adding all/none/clear text buttons.  Also place the ShowFlagsPanel next to the table of properties instead of at the top of the windows. Minor other GUI and code cleanup to affected windows including property browser, config group and preset editors, and pixel size group and preset editors.