### PR TITLE
MMStudio: add API to get profile property map directly

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/Studio.java
+++ b/mmstudio/src/main/java/org/micromanager/Studio.java
@@ -29,6 +29,7 @@ import org.micromanager.alerts.AlertManager;
 import org.micromanager.data.DataManager;
 import org.micromanager.display.DisplayManager;
 import org.micromanager.events.EventManager;
+import org.micromanager.propertymap.MutablePropertyMapView;
 import org.micromanager.quickaccess.QuickAccessManager;
 
 
@@ -209,6 +210,14 @@ public interface Studio {
     * @return UserProfile instance
     */
    public UserProfile getUserProfile();
+   
+   /**
+    * Convenience method to access the profile settings for the specified class.
+    * Equivalent to profile().getSettings(owner)
+    * @param owner
+    * @return MutablePropertyMapView
+    */
+   public MutablePropertyMapView getProfileSettings(Class<?> owner);
 
    /**
     * Provides access to the PluginManager for accessing plugin instances.

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -110,6 +110,7 @@ import org.micromanager.internal.utils.WaitDialog;
 import org.micromanager.profile.internal.DefaultUserProfile;
 import org.micromanager.profile.internal.UserProfileAdmin;
 import org.micromanager.profile.internal.gui.HardwareConfigurationManager;
+import org.micromanager.propertymap.MutablePropertyMapView;
 import org.micromanager.quickaccess.QuickAccessManager;
 import org.micromanager.quickaccess.internal.DefaultQuickAccessManager;
 
@@ -1571,6 +1572,10 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
    @Override
    public UserProfile getUserProfile() {
       return profile();
+   }
+   @Override
+   public MutablePropertyMapView getProfileSettings(Class<?> owner) {
+      return profile().getSettings(owner);
    }
 
    @Override


### PR DESCRIPTION
Created convenience method so that instead of writing e.g. `studio_.profile().getSettings(StageControlFrame.class)` you can just write `studio_.getProfileSettings(StageControlFrame.class)`. Saves a bit of time but mainly helps avoid the temptation to use deprecated methods for getting/setting profile value via UserProfile methods and jump straight to the preferred MutablePropertyMapView methods.

Would value input from @marktsuchida as well.