### PR TITLE
make the redefinition of snprintf conditional on visual studio version

### DIFF
--- a/DeviceAdapters/AAAOTF/AAAOTF.cpp
+++ b/DeviceAdapters/AAAOTF/AAAOTF.cpp
@@ -10,7 +10,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "AAAOTF.h"

--- a/DeviceAdapters/ABS/ABSCamera.h
+++ b/DeviceAdapters/ABS/ABSCamera.h
@@ -4,7 +4,9 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>   
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
    #pragma warning(disable : 4996) // disable warning for deperecated CRT functions on Windows 
 #endif
 

--- a/DeviceAdapters/ABS/CcmFileStd.cpp
+++ b/DeviceAdapters/ABS/CcmFileStd.cpp
@@ -24,7 +24,9 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>   
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
    #pragma warning(disable : 4996) // disable warning for deperecated CRT functions on Windows 
 #endif
 

--- a/DeviceAdapters/ABS/TimeSpanPC.h
+++ b/DeviceAdapters/ABS/TimeSpanPC.h
@@ -3,7 +3,9 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>   
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
    #pragma warning(disable : 4996) // disable warning for deperecated CRT functions on Windows 
 #endif
 

--- a/DeviceAdapters/ABS/absdelayloaddll.cpp
+++ b/DeviceAdapters/ABS/absdelayloaddll.cpp
@@ -1,7 +1,9 @@
 #ifdef WIN32
   #define WIN32_LEAN_AND_MEAN
   #include <windows.h>   
-  #define snprintf _snprintf 
+  #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
   #pragma warning(disable : 4996) // disable warning for deperecated CRT functions on Windows 
 #endif
 #include <stdio.h>

--- a/DeviceAdapters/AOTF/AOTF.cpp
+++ b/DeviceAdapters/AOTF/AOTF.cpp
@@ -28,7 +28,9 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
+	#if _MSC_VER<1900
+    #define snprintf _snprintf
+	#endif
 #endif
 
 #include "AOTF.h"

--- a/DeviceAdapters/ASIFW1000/ASIFW1000.cpp
+++ b/DeviceAdapters/ASIFW1000/ASIFW1000.cpp
@@ -29,7 +29,9 @@
 
 #ifdef WIN32
    //#include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "ASIFW1000.h"

--- a/DeviceAdapters/ASIWPTR/wptr.cpp
+++ b/DeviceAdapters/ASIWPTR/wptr.cpp
@@ -26,7 +26,9 @@
 
 #ifdef WIN32
    //#include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "wptr.h"

--- a/DeviceAdapters/AgilentLaserCombiner/AgilentLaserCombiner.cpp
+++ b/DeviceAdapters/AgilentLaserCombiner/AgilentLaserCombiner.cpp
@@ -13,7 +13,9 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "AgilentLaserCombiner.h"

--- a/DeviceAdapters/Aladdin/Aladdin.cpp
+++ b/DeviceAdapters/Aladdin/Aladdin.cpp
@@ -26,7 +26,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 

--- a/DeviceAdapters/AndorLaserCombiner/AndorLaserCombiner.cpp
+++ b/DeviceAdapters/AndorLaserCombiner/AndorLaserCombiner.cpp
@@ -29,7 +29,9 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 

--- a/DeviceAdapters/Apogee/Apogee.cpp
+++ b/DeviceAdapters/Apogee/Apogee.cpp
@@ -32,7 +32,9 @@
 #ifdef WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "Apogee.h"

--- a/DeviceAdapters/Arduino/Arduino.cpp
+++ b/DeviceAdapters/Arduino/Arduino.cpp
@@ -20,7 +20,9 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 const char* g_DeviceNameArduinoHub = "Arduino-Hub";

--- a/DeviceAdapters/BlueboxOptics_niji/niji.cpp
+++ b/DeviceAdapters/BlueboxOptics_niji/niji.cpp
@@ -28,7 +28,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 

--- a/DeviceAdapters/CARVII/CARVII.cpp
+++ b/DeviceAdapters/CARVII/CARVII.cpp
@@ -23,7 +23,9 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "CARVII.h"

--- a/DeviceAdapters/CNCMicroscope/ArduinoNeoPixelShutter/ArduinoNeoPixelShutter.cpp
+++ b/DeviceAdapters/CNCMicroscope/ArduinoNeoPixelShutter/ArduinoNeoPixelShutter.cpp
@@ -24,7 +24,9 @@ limitations under the License.
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 const char* g_DeviceNameArduinoNeoPixelHub = "ArduinoNeoPixel-Hub";

--- a/DeviceAdapters/CNCMicroscope/RAMPSStage/ZStage.cpp
+++ b/DeviceAdapters/CNCMicroscope/RAMPSStage/ZStage.cpp
@@ -16,7 +16,9 @@ limitations under the License.
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif
 #endif
 #include "RAMPS.h"
 

--- a/DeviceAdapters/CSUW1/CSUW1.cpp
+++ b/DeviceAdapters/CSUW1/CSUW1.cpp
@@ -33,7 +33,9 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "CSUW1.h"

--- a/DeviceAdapters/CoherentCube/CoherentCube.cpp
+++ b/DeviceAdapters/CoherentCube/CoherentCube.cpp
@@ -26,7 +26,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 

--- a/DeviceAdapters/CoherentOBIS/CoherentOBIS.cpp
+++ b/DeviceAdapters/CoherentOBIS/CoherentOBIS.cpp
@@ -24,7 +24,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "CoherentOBIS.h"

--- a/DeviceAdapters/CoherentScientificRemote/CoherentScientificRemote.cpp
+++ b/DeviceAdapters/CoherentScientificRemote/CoherentScientificRemote.cpp
@@ -25,7 +25,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "CoherentScientificRemote.h"

--- a/DeviceAdapters/Conix/Conix.cpp
+++ b/DeviceAdapters/Conix/Conix.cpp
@@ -14,7 +14,9 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif
 #endif
 
 #include "Conix.h"

--- a/DeviceAdapters/CoolLEDpE300/pE300.cpp
+++ b/DeviceAdapters/CoolLEDpE300/pE300.cpp
@@ -20,7 +20,9 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 

--- a/DeviceAdapters/CoolLEDpE4000/pE4000.cpp
+++ b/DeviceAdapters/CoolLEDpE4000/pE4000.cpp
@@ -20,7 +20,9 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 

--- a/DeviceAdapters/Corvus/Corvus.cpp
+++ b/DeviceAdapters/Corvus/Corvus.cpp
@@ -40,7 +40,9 @@
 
 #ifdef WIN32
 //   #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include <stdio.h>

--- a/DeviceAdapters/DTOpenLayer/DTOpenLayer.cpp
+++ b/DeviceAdapters/DTOpenLayer/DTOpenLayer.cpp
@@ -23,7 +23,9 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "DTOpenLayer.h"

--- a/DeviceAdapters/Diskovery/Diskovery.cpp
+++ b/DeviceAdapters/Diskovery/Diskovery.cpp
@@ -24,7 +24,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "Diskovery.h"

--- a/DeviceAdapters/Diskovery/DiskoveryModel.cpp
+++ b/DeviceAdapters/Diskovery/DiskoveryModel.cpp
@@ -24,7 +24,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 

--- a/DeviceAdapters/FLICamera/FLICamera.cpp
+++ b/DeviceAdapters/FLICamera/FLICamera.cpp
@@ -25,7 +25,9 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 
 extern "C" {
 	long __stdcall FLILibAttach(void);

--- a/DeviceAdapters/FreeSerialPort/FreeSerialPort.cpp
+++ b/DeviceAdapters/FreeSerialPort/FreeSerialPort.cpp
@@ -24,7 +24,9 @@
 #ifdef WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "FreeSerialPort.h"

--- a/DeviceAdapters/HamiltonMVP/MVPCommands.h
+++ b/DeviceAdapters/HamiltonMVP/MVPCommands.h
@@ -41,7 +41,9 @@
 #include <vector>
 
 #if defined(_MSC_VER) && _MSC_VER < 1900
-#define snprintf _snprintf
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif
 #endif
 
 

--- a/DeviceAdapters/HydraLMT200/ITKHydra.cpp
+++ b/DeviceAdapters/HydraLMT200/ITKHydra.cpp
@@ -37,7 +37,9 @@
 
 #ifdef WIN32
 //   #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include <stdio.h>

--- a/DeviceAdapters/IsmatecMCP/MCPCommands.h
+++ b/DeviceAdapters/IsmatecMCP/MCPCommands.h
@@ -40,7 +40,9 @@
 
 
 #if defined(_MSC_VER) && _MSC_VER < 1900
-#define snprintf _snprintf
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif
 #endif
 
 const char* const MCP_CMD_TERM = "\r";

--- a/DeviceAdapters/K8055/K8055.cpp
+++ b/DeviceAdapters/K8055/K8055.cpp
@@ -17,7 +17,9 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 using namespace std;

--- a/DeviceAdapters/K8061/K8061.cpp
+++ b/DeviceAdapters/K8061/K8061.cpp
@@ -18,7 +18,9 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 using namespace std;

--- a/DeviceAdapters/LeicaDMI/LeicaDMI.cpp
+++ b/DeviceAdapters/LeicaDMI/LeicaDMI.cpp
@@ -28,7 +28,9 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #else
 #include <netinet/in.h>
 #endif

--- a/DeviceAdapters/LeicaDMI/LeicaDMIModel.cpp
+++ b/DeviceAdapters/LeicaDMI/LeicaDMIModel.cpp
@@ -28,7 +28,9 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #else
 #include <netinet/in.h>
 #endif

--- a/DeviceAdapters/LeicaDMI/LeicaDMIScopeInterface.cpp
+++ b/DeviceAdapters/LeicaDMI/LeicaDMIScopeInterface.cpp
@@ -28,7 +28,9 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #else
 #include <netinet/in.h>
 #endif

--- a/DeviceAdapters/LeicaDMR/LeicaDMR.cpp
+++ b/DeviceAdapters/LeicaDMR/LeicaDMR.cpp
@@ -28,7 +28,9 @@
 
 #ifdef WIN32
    //#include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "LeicaDMR.h"

--- a/DeviceAdapters/LeicaDMSTC/LeicaDMSTC.cpp
+++ b/DeviceAdapters/LeicaDMSTC/LeicaDMSTC.cpp
@@ -24,7 +24,9 @@
 
 #ifdef WIN32
    //#include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "LeicaDMSTC.h"

--- a/DeviceAdapters/Ludl/Ludl.cpp
+++ b/DeviceAdapters/Ludl/Ludl.cpp
@@ -29,7 +29,9 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif
 #endif
 
 #include "Ludl.h"

--- a/DeviceAdapters/LudlLow/Ludl.cpp
+++ b/DeviceAdapters/LudlLow/Ludl.cpp
@@ -28,7 +28,9 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif
 #endif
 
 #include "Ludl.h"

--- a/DeviceAdapters/LumencorCIA/CIA.cpp
+++ b/DeviceAdapters/LumencorCIA/CIA.cpp
@@ -22,7 +22,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
    #include <iostream>
 #endif
 

--- a/DeviceAdapters/MP285/MP285.cpp
+++ b/DeviceAdapters/MP285/MP285.cpp
@@ -32,7 +32,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include <stdio.h>

--- a/DeviceAdapters/MP285/MP285Ctrl.cpp
+++ b/DeviceAdapters/MP285/MP285Ctrl.cpp
@@ -30,7 +30,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include <stdio.h>

--- a/DeviceAdapters/MP285/MP285Error.cpp
+++ b/DeviceAdapters/MP285/MP285Error.cpp
@@ -30,7 +30,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include <stdio.h>

--- a/DeviceAdapters/MP285/MP285XYStage.cpp
+++ b/DeviceAdapters/MP285/MP285XYStage.cpp
@@ -30,7 +30,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include <stdio.h>

--- a/DeviceAdapters/MP285/MP285ZStage.cpp
+++ b/DeviceAdapters/MP285/MP285ZStage.cpp
@@ -30,7 +30,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include <stdio.h>

--- a/DeviceAdapters/MT20/MT20.cpp
+++ b/DeviceAdapters/MT20/MT20.cpp
@@ -36,7 +36,9 @@ const char* g_MT20Filterwheel = "MT20-Filterwheel";
 const char* g_MT20Attenuator = "MT20-Attenuator";
 
 #ifdef WIN32
-	#define snprintf _snprintf
+	#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif
 #endif
 
 // instantiate MT20hub object, which will handle communication with device

--- a/DeviceAdapters/MT20/MT20hub.cpp
+++ b/DeviceAdapters/MT20/MT20hub.cpp
@@ -28,7 +28,9 @@
 
 #ifdef WIN32
 	#define close closesocket
-	#define snprintf _snprintf
+	#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif
 	//#define errno WSAGetLastError()
 	#define strerror stringerror	// defined internally to use FormatMessage() instead of strerror
 #else

--- a/DeviceAdapters/MaestroServo/MaestroServo.cpp
+++ b/DeviceAdapters/MaestroServo/MaestroServo.cpp
@@ -19,7 +19,9 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "MaestroServo.h"

--- a/DeviceAdapters/Marzhauser-LStep/LStep.cpp
+++ b/DeviceAdapters/Marzhauser-LStep/LStep.cpp
@@ -32,7 +32,9 @@
 
 #ifdef WIN32
 //   #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #pragma warning(disable: 4355)
 #endif
 

--- a/DeviceAdapters/Marzhauser/Marzhauser.cpp
+++ b/DeviceAdapters/Marzhauser/Marzhauser.cpp
@@ -33,7 +33,9 @@
 
 #ifdef WIN32
 //   #include <windows.h>
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #pragma warning(disable: 4355)
 #endif
 
@@ -1337,7 +1339,7 @@ int ZStage::Initialize()
    if ((Configuration_ & 0x0800) == 0x0800)
    {
 	  sequenceable_ = true;
-	  CPropertyAction* pAct = new CPropertyAction (this, &ZStage::OnSequence);
+	  pAct = new CPropertyAction (this, &ZStage::OnSequence);
 	  const char* spn = "Use Sequence";
 	  CreateProperty(spn, "No", MM::String, false, pAct);
       AddAllowedValue(spn, "No");

--- a/DeviceAdapters/MarzhauserLStepOld/LStepOld.cpp
+++ b/DeviceAdapters/MarzhauserLStepOld/LStepOld.cpp
@@ -19,7 +19,9 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif
 #endif
 
 #include "LStepOld.h"

--- a/DeviceAdapters/MicroPoint/MicroPoint.cpp
+++ b/DeviceAdapters/MicroPoint/MicroPoint.cpp
@@ -27,7 +27,9 @@
 //                Thanks to Sophie Dumont, Mary Elting, and Michael Mohammadi
 
 #ifdef WIN32
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #pragma warning(disable: 4355)
 #endif
 

--- a/DeviceAdapters/NI100X/NI100X.cpp
+++ b/DeviceAdapters/NI100X/NI100X.cpp
@@ -13,7 +13,9 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include <boost/lexical_cast.hpp>

--- a/DeviceAdapters/Neos/Neos.cpp
+++ b/DeviceAdapters/Neos/Neos.cpp
@@ -19,7 +19,9 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "Neos.h"

--- a/DeviceAdapters/NewportSMC/Newport.cpp
+++ b/DeviceAdapters/NewportSMC/Newport.cpp
@@ -25,7 +25,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif
 #endif
 
 #include "Newport.h"

--- a/DeviceAdapters/Nikon/Nikon.cpp
+++ b/DeviceAdapters/Nikon/Nikon.cpp
@@ -23,7 +23,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "Nikon.h"

--- a/DeviceAdapters/OVP_ECS2/OVP_ECS2.cpp
+++ b/DeviceAdapters/OVP_ECS2/OVP_ECS2.cpp
@@ -22,7 +22,9 @@
 
 
 #ifdef WIN32
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "OVP_ECS2.h"

--- a/DeviceAdapters/ObjectiveImaging/OasisControl.cpp
+++ b/DeviceAdapters/ObjectiveImaging/OasisControl.cpp
@@ -31,7 +31,9 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif
 #endif
 
 // The main Oasis controller API

--- a/DeviceAdapters/PI/PI.cpp
+++ b/DeviceAdapters/PI/PI.cpp
@@ -25,7 +25,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "PI.h"

--- a/DeviceAdapters/PICAM/PICAMUniversal.cpp
+++ b/DeviceAdapters/PICAM/PICAMUniversal.cpp
@@ -71,7 +71,9 @@ using namespace std;
 #endif
 
 #if WIN64
-#define snprintf _snprintf
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif
 #endif
 
 // Number of references to this class

--- a/DeviceAdapters/PI_GCS/PI_GCS.cpp
+++ b/DeviceAdapters/PI_GCS/PI_GCS.cpp
@@ -24,7 +24,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "PI_GCS.h"

--- a/DeviceAdapters/PVCAM/PVCAMUniversal.cpp
+++ b/DeviceAdapters/PVCAM/PVCAMUniversal.cpp
@@ -70,7 +70,9 @@ using namespace std;
 #endif
 
 #if WIN32
-#define snprintf _snprintf
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif
 #endif
 
 // Number of references to this class

--- a/DeviceAdapters/ParallelPort/ParallelPort.cpp
+++ b/DeviceAdapters/ParallelPort/ParallelPort.cpp
@@ -31,7 +31,9 @@
 #ifdef WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "ParallelPort.h"

--- a/DeviceAdapters/Pecon/Pecon.cpp
+++ b/DeviceAdapters/Pecon/Pecon.cpp
@@ -10,7 +10,9 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "Pecon.h"

--- a/DeviceAdapters/Piezosystem_30DV50/Piezosystem_30DV50.cpp
+++ b/DeviceAdapters/Piezosystem_30DV50/Piezosystem_30DV50.cpp
@@ -34,7 +34,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "Piezosystem_30DV50.h"

--- a/DeviceAdapters/Piezosystem_NV120_1/Piezosystem_NV120_1.cpp
+++ b/DeviceAdapters/Piezosystem_NV120_1/Piezosystem_NV120_1.cpp
@@ -33,7 +33,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "Piezosystem_NV120_1.h"

--- a/DeviceAdapters/Piezosystem_NV40_1/Piezosystem_NV40_1.cpp
+++ b/DeviceAdapters/Piezosystem_NV40_1/Piezosystem_NV40_1.cpp
@@ -34,7 +34,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "Piezosystem_NV40_1.h"

--- a/DeviceAdapters/Piezosystem_NV40_3/Piezosystem_NV40_3.cpp
+++ b/DeviceAdapters/Piezosystem_NV40_3/Piezosystem_NV40_3.cpp
@@ -34,7 +34,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "Piezosystem_NV40_3.h"

--- a/DeviceAdapters/Piezosystem_dDrive/Piezosystem_dDrive.cpp
+++ b/DeviceAdapters/Piezosystem_dDrive/Piezosystem_dDrive.cpp
@@ -36,7 +36,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "Piezosystem_dDrive.h"

--- a/DeviceAdapters/Piper/stdafx.h
+++ b/DeviceAdapters/Piper/stdafx.h
@@ -28,7 +28,9 @@
 
 #include <Windows.h>
 
-#define snprintf _snprintf
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif
 
 #define __PIPER_API_EXPORT __declspec(dllimport)
 

--- a/DeviceAdapters/PrecisExcite/PrecisExcite.cpp
+++ b/DeviceAdapters/PrecisExcite/PrecisExcite.cpp
@@ -26,7 +26,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 

--- a/DeviceAdapters/Prior/Prior.cpp
+++ b/DeviceAdapters/Prior/Prior.cpp
@@ -23,7 +23,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "prior.h"

--- a/DeviceAdapters/PriorLegacy/PriorLegacy.cpp
+++ b/DeviceAdapters/PriorLegacy/PriorLegacy.cpp
@@ -29,7 +29,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "PriorLegacy.h"

--- a/DeviceAdapters/Rapp/Rapp.cpp
+++ b/DeviceAdapters/Rapp/Rapp.cpp
@@ -27,7 +27,9 @@
 //                Special thanks to Andre Ratz
 
 #ifdef WIN32
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #pragma warning(disable: 4355)
 #endif
 

--- a/DeviceAdapters/Sapphire/Sapphire.cpp
+++ b/DeviceAdapters/Sapphire/Sapphire.cpp
@@ -26,7 +26,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 

--- a/DeviceAdapters/Scientifica/Scientifica.cpp
+++ b/DeviceAdapters/Scientifica/Scientifica.cpp
@@ -24,7 +24,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "Scientifica.h"

--- a/DeviceAdapters/ScionCam/ScionCamera.cpp
+++ b/DeviceAdapters/ScionCam/ScionCamera.cpp
@@ -41,7 +41,9 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "ScionCamera.h"

--- a/DeviceAdapters/ScionCam/capture.cpp
+++ b/DeviceAdapters/ScionCam/capture.cpp
@@ -40,7 +40,9 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include	"ScionCamera.h"

--- a/DeviceAdapters/ScionCam/utilities.cpp
+++ b/DeviceAdapters/ScionCam/utilities.cpp
@@ -40,7 +40,9 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include	"ScionCamera.h"

--- a/DeviceAdapters/Sensicam/Sensicam.cpp
+++ b/DeviceAdapters/Sensicam/Sensicam.cpp
@@ -52,7 +52,9 @@ const char* g_PixelType_8bit = "8bit";
 const char* g_PixelType_16bit = "16bit";
 
 #ifdef WIN32
-   #define snprintf _snprintf
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/DeviceAdapters/SimpleAutofocus/FocusMonitor.cpp
+++ b/DeviceAdapters/SimpleAutofocus/FocusMonitor.cpp
@@ -29,7 +29,9 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "SimpleAutofocus.h"

--- a/DeviceAdapters/SimpleAutofocus/SimpleAutofocus.cpp
+++ b/DeviceAdapters/SimpleAutofocus/SimpleAutofocus.cpp
@@ -26,7 +26,9 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif
 #endif
 
 

--- a/DeviceAdapters/SmarActHCU-3D/SmarActHCU-3D.cpp
+++ b/DeviceAdapters/SmarActHCU-3D/SmarActHCU-3D.cpp
@@ -13,7 +13,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "SmarActHCU-3D.h"

--- a/DeviceAdapters/Spot(Windows)/SpotCamera.cpp
+++ b/DeviceAdapters/Spot(Windows)/SpotCamera.cpp
@@ -25,7 +25,9 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include <string>

--- a/DeviceAdapters/Standa/Standa.cpp
+++ b/DeviceAdapters/Standa/Standa.cpp
@@ -22,7 +22,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "Standa.h"

--- a/DeviceAdapters/SutterLambda/SutterLambda.cpp
+++ b/DeviceAdapters/SutterLambda/SutterLambda.cpp
@@ -21,7 +21,9 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "SutterLambda.h"

--- a/DeviceAdapters/SutterStage/SutterStage.cpp
+++ b/DeviceAdapters/SutterStage/SutterStage.cpp
@@ -29,7 +29,9 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif
 #endif
 
 #include "SutterStage.h"

--- a/DeviceAdapters/Thorlabs/IntegratedFilterWheel.cpp
+++ b/DeviceAdapters/Thorlabs/IntegratedFilterWheel.cpp
@@ -24,7 +24,9 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 // Prevent "unused variable" warnings.

--- a/DeviceAdapters/Thorlabs/MotorZStage.cpp
+++ b/DeviceAdapters/Thorlabs/MotorZStage.cpp
@@ -23,7 +23,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "MotorZStage.h"

--- a/DeviceAdapters/Thorlabs/PiezoZStage.cpp
+++ b/DeviceAdapters/Thorlabs/PiezoZStage.cpp
@@ -24,7 +24,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "PiezoZStage.h"

--- a/DeviceAdapters/Thorlabs/Thorlabs.cpp
+++ b/DeviceAdapters/Thorlabs/Thorlabs.cpp
@@ -22,7 +22,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "Thorlabs.h"

--- a/DeviceAdapters/ThorlabsAPTStage/ThorlabsAPTStage.cpp
+++ b/DeviceAdapters/ThorlabsAPTStage/ThorlabsAPTStage.cpp
@@ -41,7 +41,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif
 #endif
 
 #include "ThorlabsAPTStage.h"

--- a/DeviceAdapters/ThorlabsDCStage/ThorlabsDCStage.cpp
+++ b/DeviceAdapters/ThorlabsDCStage/ThorlabsDCStage.cpp
@@ -23,7 +23,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "ThorlabsDCStage.h"

--- a/DeviceAdapters/ThorlabsDCxxxx/DCxxxx_Plugin.cpp
+++ b/DeviceAdapters/ThorlabsDCxxxx/DCxxxx_Plugin.cpp
@@ -24,7 +24,9 @@
 
 #ifdef WIN32
 	#include <windows.h>
-	#define snprintf _snprintf
+	#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif
 #endif
 #include <string>
 #include <math.h>

--- a/DeviceAdapters/ThorlabsFilterWheel/FilterWheel.cpp
+++ b/DeviceAdapters/ThorlabsFilterWheel/FilterWheel.cpp
@@ -27,7 +27,9 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "FilterWheel.h"

--- a/DeviceAdapters/ThorlabsSC10/SC10.cpp
+++ b/DeviceAdapters/ThorlabsSC10/SC10.cpp
@@ -12,7 +12,9 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "SC10.h"

--- a/DeviceAdapters/Tofra/Tofra.cpp
+++ b/DeviceAdapters/Tofra/Tofra.cpp
@@ -24,7 +24,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "Tofra.h"

--- a/DeviceAdapters/VariLC/VariLC.cpp
+++ b/DeviceAdapters/VariLC/VariLC.cpp
@@ -38,7 +38,9 @@
 
 #ifdef WIN32
 //   #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "VariLC.h"

--- a/DeviceAdapters/Vincent/Vincent.cpp
+++ b/DeviceAdapters/Vincent/Vincent.cpp
@@ -22,7 +22,9 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "Vincent.h"

--- a/DeviceAdapters/Vortran/Stradus.cpp
+++ b/DeviceAdapters/Vortran/Stradus.cpp
@@ -23,7 +23,9 @@
 #include "Stradus.h"
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif
 #endif
 
 #include "../../MMDevice/MMDevice.h"

--- a/DeviceAdapters/Vortran/VersaLase.cpp
+++ b/DeviceAdapters/Vortran/VersaLase.cpp
@@ -50,7 +50,9 @@
 #include "VersaLase.h"
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif
 #endif
 
 #include "../../MMDevice/MMDevice.h"

--- a/DeviceAdapters/WieneckeSinske/CAN29.cpp
+++ b/DeviceAdapters/WieneckeSinske/CAN29.cpp
@@ -28,7 +28,9 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "CAN29.h"

--- a/DeviceAdapters/WieneckeSinske/WieneckeSinske.cpp
+++ b/DeviceAdapters/WieneckeSinske/WieneckeSinske.cpp
@@ -29,7 +29,9 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "WieneckeSinske.h"

--- a/DeviceAdapters/XCite120PC_Exacte/XCite.cpp
+++ b/DeviceAdapters/XCite120PC_Exacte/XCite.cpp
@@ -23,7 +23,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif
 #endif
 
 #include "XCite120PC.h"

--- a/DeviceAdapters/XCite120PC_Exacte/XCite120PC.cpp
+++ b/DeviceAdapters/XCite120PC_Exacte/XCite120PC.cpp
@@ -27,7 +27,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "XCite120PC.h"

--- a/DeviceAdapters/XCite120PC_Exacte/XCiteExacte.cpp
+++ b/DeviceAdapters/XCite120PC_Exacte/XCiteExacte.cpp
@@ -28,7 +28,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "XCiteExacte.h"

--- a/DeviceAdapters/XCiteLed/XLed.cpp
+++ b/DeviceAdapters/XCiteLed/XLed.cpp
@@ -30,7 +30,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include <stdio.h>

--- a/DeviceAdapters/XCiteLed/XLedCtrl.cpp
+++ b/DeviceAdapters/XCiteLed/XLedCtrl.cpp
@@ -30,7 +30,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include <stdio.h>

--- a/DeviceAdapters/XCiteLed/XLedDev.cpp
+++ b/DeviceAdapters/XCiteLed/XLedDev.cpp
@@ -30,7 +30,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include <stdio.h>

--- a/DeviceAdapters/XCiteXT600/XT600.cpp
+++ b/DeviceAdapters/XCiteXT600/XT600.cpp
@@ -30,7 +30,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include <stdio.h>

--- a/DeviceAdapters/XCiteXT600/XT600Ctrl.cpp
+++ b/DeviceAdapters/XCiteXT600/XT600Ctrl.cpp
@@ -30,7 +30,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include <stdio.h>

--- a/DeviceAdapters/XCiteXT600/XT600Dev.cpp
+++ b/DeviceAdapters/XCiteXT600/XT600Dev.cpp
@@ -30,7 +30,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include <stdio.h>

--- a/DeviceAdapters/XLight/XLight.cpp
+++ b/DeviceAdapters/XLight/XLight.cpp
@@ -23,7 +23,9 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "XLight.h"

--- a/DeviceAdapters/Xcite/Xcite.cpp
+++ b/DeviceAdapters/Xcite/Xcite.cpp
@@ -23,7 +23,9 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "Xcite.h"

--- a/DeviceAdapters/Yokogawa/CSU22.cpp
+++ b/DeviceAdapters/Yokogawa/CSU22.cpp
@@ -33,7 +33,9 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "CSU22.h"

--- a/DeviceAdapters/Yokogawa/CSUX.cpp
+++ b/DeviceAdapters/Yokogawa/CSUX.cpp
@@ -33,7 +33,9 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "CSUX.h"

--- a/DeviceAdapters/Zaber/FilterWheel.cpp
+++ b/DeviceAdapters/Zaber/FilterWheel.cpp
@@ -21,7 +21,9 @@
 //                INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
 
 #ifdef WIN32
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #pragma warning(disable: 4355)
 #endif
 

--- a/DeviceAdapters/Zaber/Stage.cpp
+++ b/DeviceAdapters/Zaber/Stage.cpp
@@ -21,7 +21,9 @@
 //                INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES.
 
 #ifdef WIN32
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #pragma warning(disable: 4355)
 #endif
 

--- a/DeviceAdapters/Zaber/XYStage.cpp
+++ b/DeviceAdapters/Zaber/XYStage.cpp
@@ -22,7 +22,9 @@
 //
 
 #ifdef WIN32
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #pragma warning(disable: 4355)
 #endif
 

--- a/DeviceAdapters/Zaber/Zaber.cpp
+++ b/DeviceAdapters/Zaber/Zaber.cpp
@@ -22,7 +22,9 @@
 //
 
 #ifdef WIN32
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #pragma warning(disable: 4355)
 #endif
 

--- a/DeviceAdapters/ZeissCAN/PhotoModule.cpp
+++ b/DeviceAdapters/ZeissCAN/PhotoModule.cpp
@@ -1,7 +1,9 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif
 #endif
 
 #include "ZeissCAN.h"

--- a/DeviceAdapters/ZeissCAN/ZStage.cpp
+++ b/DeviceAdapters/ZeissCAN/ZStage.cpp
@@ -10,7 +10,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "ZeissCAN.h"

--- a/DeviceAdapters/ZeissCAN/ZeissCAN.cpp
+++ b/DeviceAdapters/ZeissCAN/ZeissCAN.cpp
@@ -30,7 +30,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "ZeissCAN.h"

--- a/DeviceAdapters/ZeissCAN/mcu28.cpp
+++ b/DeviceAdapters/ZeissCAN/mcu28.cpp
@@ -31,7 +31,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include "ZeissCAN.h"

--- a/DeviceAdapters/ZeissCAN29/ZeissCAN29.h
+++ b/DeviceAdapters/ZeissCAN29/ZeissCAN29.h
@@ -45,7 +45,9 @@
 #ifdef WIN32
 #include <windows.h>
 #include <winsock.h>
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #else
 #include <netinet/in.h>
 #endif

--- a/DeviceAdapters/kdv/KDV.cpp
+++ b/DeviceAdapters/kdv/KDV.cpp
@@ -31,7 +31,9 @@
 
 #ifdef WIN32
 #include <windows.h>
-#define snprintf _snprintf
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif
 #endif
 
 #include "KDV.h"

--- a/DeviceAdapters/nPoint/nPC400.cpp
+++ b/DeviceAdapters/nPoint/nPC400.cpp
@@ -30,7 +30,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include <stdio.h>

--- a/DeviceAdapters/nPoint/nPC400Channel.cpp
+++ b/DeviceAdapters/nPoint/nPC400Channel.cpp
@@ -30,7 +30,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include <stdio.h>

--- a/DeviceAdapters/nPoint/nPC400Ctrl.cpp
+++ b/DeviceAdapters/nPoint/nPC400Ctrl.cpp
@@ -30,7 +30,9 @@
 
 #ifdef WIN32
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #endif
 
 #include <stdio.h>

--- a/DeviceAdapters/pgFocus/pgFocus.cpp
+++ b/DeviceAdapters/pgFocus/pgFocus.cpp
@@ -16,7 +16,9 @@
 //
 
 #ifdef WIN32
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #pragma warning(disable: 4355)
 #endif
 

--- a/DeviceAdapters/pgFocus/pgFocus.h
+++ b/DeviceAdapters/pgFocus/pgFocus.h
@@ -20,7 +20,9 @@
 #ifdef WIN32
 #include <windows.h>
 #include <winsock.h>
-#define snprintf _snprintf
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif
 #else
 #include <netinet/in.h>
 #endif

--- a/MMCore/Host.cpp
+++ b/MMCore/Host.cpp
@@ -27,7 +27,9 @@
 #include <winsock2.h>
 #include "Iphlpapi.h"
 #include <stdio.h>
-#define snprintf _snprintf 
+#if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 
 #endif //_WINDOWS
 

--- a/MMDevice/DeviceUtils.cpp
+++ b/MMDevice/DeviceUtils.cpp
@@ -27,7 +27,9 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf 
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif 
 #else
    #include <unistd.h>
 #endif

--- a/MMDevice/MMDevice.h
+++ b/MMDevice/MMDevice.h
@@ -72,7 +72,9 @@
 #ifdef WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
-   #define snprintf _snprintf
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif
 
    typedef HMODULE HDEVMODULE;
 #else

--- a/MMDevice/Property.cpp
+++ b/MMDevice/Property.cpp
@@ -27,7 +27,9 @@
 using namespace std;
 
 #if WIN32
-   #define snprintf _snprintf
+   #if _MSC_VER<1900
+    #define snprintf _snprintf
+#endif
 #endif
 
 const int BUFSIZE = 60; // For number-to-string conversion


### PR DESCRIPTION
Many of the device adapters have redefined snprintf as _snprintf because it used to be that snprintf was not defined in visual studio. Since VS2015 snprintf is now available and this redefinition prevents the projects from compiling. The PR checks the compiler version to decide whether or not redefinition of snprintf should take place.