### PR TITLE
fix display of Acquire Multiple Regions plugin

### DIFF
--- a/plugins/AcquireMultipleRegions/src/main/java/org/micromanager/acquiremultipleregions/AcquireMultipleRegionsForm.form
+++ b/plugins/AcquireMultipleRegions/src/main/java/org/micromanager/acquiremultipleregions/AcquireMultipleRegionsForm.form
@@ -85,11 +85,11 @@
                                   <Component id="deleteAllButton" alignment="1" max="32767" attributes="0"/>
                                   <Component id="StartAcquisition" alignment="1" max="32767" attributes="0"/>
                                   <Component id="addPointToRegion" max="32767" attributes="0"/>
-                                  <Group type="102" attributes="0">
+                                  <Component id="regionText" alignment="0" max="32767" attributes="0"/>
+                                  <Group type="102" alignment="0" attributes="0">
                                       <Component id="statusText" min="-2" max="-2" attributes="0"/>
                                       <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
                                   </Group>
-                                  <Component id="regionText" alignment="0" max="32767" attributes="0"/>
                               </Group>
                           </Group>
                       </Group>
@@ -138,7 +138,7 @@
                       <Group type="103" groupAlignment="0" attributes="0">
                           <Group type="102" attributes="0">
                               <Component id="deleteAllButton" min="-2" pref="41" max="-2" attributes="0"/>
-                              <EmptySpace type="separate" max="-2" attributes="0"/>
+                              <EmptySpace max="-2" attributes="0"/>
                               <Component id="StartAcquisition" min="-2" pref="41" max="-2" attributes="0"/>
                               <EmptySpace max="-2" attributes="0"/>
                               <Component id="statusText" min="-2" max="-2" attributes="0"/>


### PR DESCRIPTION
This simply moves the status display so that it is actually within the confines of the window.