### PR TITLE
Fix acquire multiple corrupt metadata gamma

### DIFF
--- a/plugins/AcquireMultipleRegions/src/main/java/org/micromanager/acquiremultipleregions/AcquireMultipleRegionsForm.java
+++ b/plugins/AcquireMultipleRegions/src/main/java/org/micromanager/acquiremultipleregions/AcquireMultipleRegionsForm.java
@@ -4,6 +4,7 @@ package org.micromanager.acquiremultipleregions;
 
 import java.awt.Font;
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -241,6 +242,7 @@ public class AcquireMultipleRegionsForm extends javax.swing.JFrame {
                 store.freeze();
                 gui_.displays().closeDisplaysFor(store);
                 store.close();
+                gui_.positions().getPositionList().save(Paths.get(store.getSavePath()).resolve("AMRposlist.pos").toFile());
             } catch (Exception ex) {
                 handleError(ex);
             }

--- a/plugins/AcquireMultipleRegions/src/main/java/org/micromanager/acquiremultipleregions/AcquireMultipleRegionsForm.java
+++ b/plugins/AcquireMultipleRegions/src/main/java/org/micromanager/acquiremultipleregions/AcquireMultipleRegionsForm.java
@@ -241,7 +241,7 @@ public class AcquireMultipleRegionsForm extends javax.swing.JFrame {
                 store.freeze();
                 gui_.displays().closeDisplaysFor(store);
                 store.close();
-            } catch (IllegalThreadStateException ex) {
+            } catch (Exception ex) {
                 handleError(ex);
             }
         }

--- a/plugins/AcquireMultipleRegions/src/main/java/org/micromanager/acquiremultipleregions/AcquireMultipleRegionsForm.java
+++ b/plugins/AcquireMultipleRegions/src/main/java/org/micromanager/acquiremultipleregions/AcquireMultipleRegionsForm.java
@@ -238,7 +238,9 @@ public class AcquireMultipleRegionsForm extends javax.swing.JFrame {
                 gui_.positions().setPositionList(currRegion.tileGrid(getXFieldSize(), getYFieldSize(), axisList_, zGenType_));               
                 gui_.app().refreshGUI();
                 Datastore store = gui_.acquisitions().runAcquisition(currRegion.filename, currRegion.directory);
+                store.freeze();
                 gui_.displays().closeDisplaysFor(store);
+                store.close();
             } catch (IllegalThreadStateException ex) {
                 handleError(ex);
             }

--- a/plugins/AcquireMultipleRegions/src/main/java/org/micromanager/acquiremultipleregions/Region.java
+++ b/plugins/AcquireMultipleRegions/src/main/java/org/micromanager/acquiremultipleregions/Region.java
@@ -166,6 +166,7 @@ class Region {
                   MSP.add(newSP);
                }
             }
+                MSP.setLabel("Pos_" + String.format("%03d", xidx) + "_" + String.format("%03d", yidx));
             PL.addPosition(MSP);
          }
          //Update Y coordinate


### PR DESCRIPTION
This fixes an issue where files saved with AcquireMultiple regions had no metadata and were just named "Undefined" this made it impossible to stitch the files. The position list used for acquisition will now also be saved for later use.