### PR TITLE
Minor display fix for HCS plugin

### DIFF
--- a/plugins/HCS/src/main/java/org/micromanager/hcs/PlatePanel.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/PlatePanel.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Hashtable;
 
 import javax.swing.JPanel;
+import mmcorej.DeviceType;
 
 import org.micromanager.PositionList;
 import org.micromanager.Studio;
@@ -238,7 +239,7 @@ public class PlatePanel extends JPanel {
             if (gui_.useThreePtAF() && gui_.getThreePointZPos(pt.x, pt.y) != null)
                app_.getCMMCore().setPosition(
                      gui_.getThreePointZPos(pt.x, pt.y));
-            
+            app_.getCMMCore().waitForDeviceType(DeviceType.XYStageDevice); //wait for the stage to stop moving before updating the gui.
             xyStagePos_ = app_.getCMMCore().getXYStagePosition();
             zStagePos_ = app_.getCMMCore().getPosition(app_.getCMMCore().getFocusDevice());
             gui_.updateStagePositions(xyStagePos_.x, xyStagePos_.y, zStagePos_, well, "undefined");


### PR DESCRIPTION
When using the mouse to move the stage in the HCS plugin the callback requests the new position from the device adapter without waiting for the stage to move. This makes it appear that nothing has happened, even though the position marker refreshes it ends up in it's original position. This PR waits for the stage to reach it's position before updating the position marker.