### PR TITLE
Allow HCS to save calibration and avoid resetting XY stage coordinates.

### DIFF
--- a/plugins/HCS/src/main/java/org/micromanager/hcs/CalibrationFrame.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/CalibrationFrame.java
@@ -236,7 +236,7 @@ public class CalibrationFrame extends JFrame {
                 if ("Recommended".equals(methodCombo.getSelectedItem())) { 
                     double x = studio.core().getXPosition();
                     double y = studio.core().getYPosition();
-                    offset = new Point2D.Double(pt.getX() + x, pt.getY() + y);
+                    offset = new Point2D.Double(x - pt.getX(), y - pt.getY());
                     saveCalibration = true;
                    JOptionPane.showMessageDialog(ourFrame, 
                            "Plugin offset set at position: " + offset.x + "," + offset.y);

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/CalibrationFrame.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/CalibrationFrame.java
@@ -206,13 +206,14 @@ public class CalibrationFrame extends JFrame {
                }
             }     
             try {
-               studio.getCMMCore().setAdapterOriginXY(
-                       plate.getFirstWellX() + (colNr - 1) * plate.getWellSpacingX(), 
-                       plate.getFirstWellY() + (rowNr  - 1) * plate.getWellSpacingY() );
-               siteGenerator.finishCalibration();
-               Point2D.Double pt = studio.getCMMCore().getXYStagePosition();
+                Point2D.Double pt = new Point2D.Double(plate.getFirstWellX() + (colNr - 1) * plate.getWellSpacingX(),
+                        plate.getFirstWellY() + (rowNr  - 1) * plate.getWellSpacingY());
+                double x = studio.core().getXPosition();
+                double y = studio.core().getYPosition();
+                pt.setLocation(pt.getX() - x, pt.getY() - y);
+               siteGenerator.finishCalibration(pt);
                JOptionPane.showMessageDialog(ourFrame, 
-                       "XY Stage set at position: " + pt.x + "," + pt.y);
+                       "Plugin origin set at position: " + pt.x + "," + pt.y);
             } catch (Exception ex) {
                studio.logs().showError(ex, "Failed to reset the stage's coordinates");
             }

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/ParentPlateGUI.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/ParentPlateGUI.java
@@ -1,7 +1,7 @@
 package org.micromanager.hcs;
 
 import org.micromanager.PositionList;
-
+import java.awt.geom.Point2D;
 
 public interface ParentPlateGUI {
    public void updatePointerXYPosition(double x, double y, String wellLabel, String siteLabel);
@@ -11,4 +11,5 @@ public interface ParentPlateGUI {
    public PositionList getThreePointList();
    public Double getThreePointZPos(double x, double y);
    public void displayError(String errTxt);
+   public Point2D.Double getOffset();
 }

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/ParentPlateGUI.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/ParentPlateGUI.java
@@ -12,4 +12,5 @@ public interface ParentPlateGUI {
    public Double getThreePointZPos(double x, double y);
    public void displayError(String errTxt);
    public Point2D.Double getOffset();
+   public Point2D.Double applyOffset(Point2D.Double pt);
 }

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/PlatePanel.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/PlatePanel.java
@@ -325,12 +325,15 @@ public class PlatePanel extends JPanel {
    private Point2D.Double scalePixelToDevice(int x, int y) {
       int pixelPosY = y - activeRect_.y;
       int pixelPosX = x - activeRect_.x;
-      return new Point2D.Double(pixelPosX/drawingParams_.xFactor, pixelPosY/drawingParams_.yFactor);
+      Point2D.Double offset = gui_.getOffset();
+
+      return new Point2D.Double(pixelPosX/drawingParams_.xFactor - offset.getX(), pixelPosY/drawingParams_.yFactor - offset.getY());
    }
    
    private Point scaleDeviceToPixel(double x, double y) {
-      int pixX = (int)(x * drawingParams_.xFactor + activeRect_.x + 0.5);
-      int pixY = (int)(y * drawingParams_.yFactor + activeRect_.y + 0.5);
+       Point2D.Double offset = gui_.getOffset();
+      int pixX = (int)((x + offset.getX()) * drawingParams_.xFactor + activeRect_.x + 0.5);
+      int pixY = (int)((y + offset.getY()) * drawingParams_.yFactor + activeRect_.y + 0.5);
       
       return new Point(pixX, pixY);
    }

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/PlatePanel.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/PlatePanel.java
@@ -225,7 +225,7 @@ public class PlatePanel extends JPanel {
    }
 
    protected void onMouseClicked(MouseEvent e) throws HCSException {
-      Point2D.Double pt = scalePixelToDevice(e.getX(), e.getY());
+      Point2D.Double pt = scalePixelToPlate(e.getX(), e.getY());
       String well = plate_.getWellLabel(pt.x, pt.y);
       if (mode_ == Tool.MOVE) {
          if (app_ == null)
@@ -235,6 +235,7 @@ public class PlatePanel extends JPanel {
             return;
 
          try {
+             pt = gui_.applyOffset(pt);
             app_.getCMMCore().setXYPosition(pt.x, pt.y);
             if (gui_.useThreePtAF() && gui_.getThreePointZPos(pt.x, pt.y) != null)
                app_.getCMMCore().setPosition(
@@ -317,23 +318,22 @@ public class PlatePanel extends JPanel {
       if (gui_ == null)
          return;
 
-      Point2D.Double pt = scalePixelToDevice(e.getX(), e.getY());
+      Point2D.Double pt = scalePixelToPlate(e.getX(), e.getY());
       String well = plate_.getWellLabel(pt.x, pt.y);
       gui_.updatePointerXYPosition(pt.x, pt.y, well, "");
    }
+   
+   private Point2D.Double scalePixelToPlate(int x, int y){
+        int pixelPosY = y - activeRect_.y;
+        int pixelPosX = x - activeRect_.x;
+        return new Point2D.Double(pixelPosX/drawingParams_.xFactor, pixelPosY/drawingParams_.yFactor);
 
-   private Point2D.Double scalePixelToDevice(int x, int y) {
-      int pixelPosY = y - activeRect_.y;
-      int pixelPosX = x - activeRect_.x;
-      Point2D.Double offset = gui_.getOffset();
-
-      return new Point2D.Double(pixelPosX/drawingParams_.xFactor - offset.getX(), pixelPosY/drawingParams_.yFactor - offset.getY());
    }
    
    private Point scaleDeviceToPixel(double x, double y) {
        Point2D.Double offset = gui_.getOffset();
-      int pixX = (int)((x + offset.getX()) * drawingParams_.xFactor + activeRect_.x + 0.5);
-      int pixY = (int)((y + offset.getY()) * drawingParams_.yFactor + activeRect_.y + 0.5);
+      int pixX = (int)((x - offset.getX()) * drawingParams_.xFactor + activeRect_.x + 0.5);
+      int pixY = (int)((y - offset.getY()) * drawingParams_.yFactor + activeRect_.y + 0.5);
       
       return new Point(pixX, pixY);
    }

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/PlatePanel.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/PlatePanel.java
@@ -225,7 +225,7 @@ public class PlatePanel extends JPanel {
    }
 
    protected void onMouseClicked(MouseEvent e) throws HCSException {
-      Point2D.Double pt = scalePixelToPlate(e.getX(), e.getY());
+      Point2D.Double pt = scalePixelToDevice(e.getX(), e.getY());
       String well = plate_.getWellLabel(pt.x, pt.y);
       if (mode_ == Tool.MOVE) {
          if (app_ == null)
@@ -318,12 +318,13 @@ public class PlatePanel extends JPanel {
       if (gui_ == null)
          return;
 
-      Point2D.Double pt = scalePixelToPlate(e.getX(), e.getY());
+      Point2D.Double pt = scalePixelToDevice(e.getX(), e.getY());
       String well = plate_.getWellLabel(pt.x, pt.y);
       gui_.updatePointerXYPosition(pt.x, pt.y, well, "");
    }
    
-   private Point2D.Double scalePixelToPlate(int x, int y){
+   private Point2D.Double scalePixelToDevice(int x, int y){
+        //Thge point returned from this method will still need to have the offset applied to it in order to map to the device coordinate system.
         int pixelPosY = y - activeRect_.y;
         int pixelPosX = x - activeRect_.x;
         return new Point2D.Double(pixelPosX/drawingParams_.xFactor, pixelPosY/drawingParams_.yFactor);

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
@@ -664,9 +664,9 @@ public class SiteGenerator extends MMFrame implements ParentPlateGUI {
       if (statusLabel_ == null) {
          return;
       }
-
-      String statusTxt = "Cursor: X=" + TextUtils.FMT2.format(cursorPos_.x) + "um, Y=" + TextUtils.FMT2.format(cursorPos_.y) + "um, " + cursorWell_
-              + ((useThreePtAF() && focusPlane_ != null) ? ", Z->" + TextUtils.FMT2.format(focusPlane_.getZPos(cursorPos_.x, cursorPos_.y)) + "um" : "")
+      Point2D.Double cursorOffsetPos = applyOffset(cursorPos_);
+      String statusTxt = "Cursor: X=" + TextUtils.FMT2.format(cursorOffsetPos.x) + "um, Y=" + TextUtils.FMT2.format(cursorOffsetPos.y) + "um, " + cursorWell_
+              + ((useThreePtAF() && focusPlane_ != null) ? ", Z->" + TextUtils.FMT2.format(focusPlane_.getZPos(cursorOffsetPos.x, cursorOffsetPos.y)) + "um" : "")
               + " -- Stage: X=" + TextUtils.FMT2.format(xyStagePos_.x) + "um, Y=" + TextUtils.FMT2.format(xyStagePos_.y) + "um, Z=" + TextUtils.FMT2.format(zStagePos_) + "um, "
               + stageWell_;
       statusLabel_.setText(statusTxt);

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
@@ -69,6 +69,7 @@ public class SiteGenerator extends MMFrame implements ParentPlateGUI {
    private PlatePanel platePanel_;
    private Studio app_;
    private final Point2D.Double xyStagePos_;
+   private Point2D.Double origin_;
    private double zStagePos_;
    private final Point2D.Double cursorPos_;
    private String stageWell_;
@@ -531,8 +532,8 @@ public class SiteGenerator extends MMFrame implements ParentPlateGUI {
             for (int k = 0; k < mpl.size(); k++) {
                StagePosition sp = mpl.get(k);
                if (sp.is2DStagePosition()) {
-                  sp.set2DPosition(mpl.getDefaultXYStage(), sp.get2DPositionX(), 
-                          sp.get2DPositionY());
+                  sp.set2DPosition(mpl.getDefaultXYStage(), sp.get2DPositionX() - origin_.getX(), 
+                          sp.get2DPositionY() - origin_.getY());
                }
             }
             // add Z position if 3-point focus is enabled
@@ -694,7 +695,8 @@ public class SiteGenerator extends MMFrame implements ParentPlateGUI {
       }
    }
 
-   public void finishCalibration() {
+   public void finishCalibration(Point2D.Double origin) {
+       origin_ = origin;
       regenerate();
       moveStage_.setEnabled(true);
    }

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
@@ -69,7 +69,7 @@ public class SiteGenerator extends MMFrame implements ParentPlateGUI {
    private PlatePanel platePanel_;
    private Studio app_;
    private final Point2D.Double xyStagePos_;
-   private Point2D.Double origin_;
+   private Point2D.Double offset_;
    private double zStagePos_;
    private final Point2D.Double cursorPos_;
    private String stageWell_;
@@ -532,8 +532,8 @@ public class SiteGenerator extends MMFrame implements ParentPlateGUI {
             for (int k = 0; k < mpl.size(); k++) {
                StagePosition sp = mpl.get(k);
                if (sp.is2DStagePosition()) {
-                  sp.set2DPosition(mpl.getDefaultXYStage(), sp.get2DPositionX() - origin_.getX(), 
-                          sp.get2DPositionY() - origin_.getY());
+                  sp.set2DPosition(mpl.getDefaultXYStage(), sp.get2DPositionX() + offset_.getX(), 
+                          sp.get2DPositionY() + offset_.getY());
                }
             }
             // add Z position if 3-point focus is enabled
@@ -695,8 +695,8 @@ public class SiteGenerator extends MMFrame implements ParentPlateGUI {
       }
    }
 
-   public void finishCalibration(Point2D.Double origin) {
-       origin_ = origin;
+   public void finishCalibration(Point2D.Double offset) {
+       offset_ = offset;
       regenerate();
       moveStage_.setEnabled(true);
    }

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
@@ -70,6 +70,7 @@ public class SiteGenerator extends MMFrame implements ParentPlateGUI {
    private Studio app_;
    private final Point2D.Double xyStagePos_;
    private Point2D.Double offset_;
+   private Boolean saveCalibration_;
    private double zStagePos_;
    private final Point2D.Double cursorPos_;
    private String stageWell_;
@@ -82,6 +83,7 @@ public class SiteGenerator extends MMFrame implements ParentPlateGUI {
    private final String SITE_OVERLAP    = "site_overlap"; //in µm
    private final String SITE_ROWS       = "site_rows";
    private final String SITE_COLS       = "site_cols";
+   private final String SITE_OFFSET     = "site_offset"; // in µm
 
    private final JLabel statusLabel_;
    private final JCheckBox chckbxThreePt_;
@@ -498,6 +500,14 @@ public class SiteGenerator extends MMFrame implements ParentPlateGUI {
             rowsField_.getText());
       app_.profile().setString(SiteGenerator.class, SITE_COLS,
             columnsField_.getText());
+      Double[] offset;
+      if (saveCalibration_) {
+          offset = new Double[] {offset_.getX(), offset_.getY()};
+      } else {
+          offset = new Double[] {Double.NaN, Double.NaN};
+      }
+      app_.profile().setDoubleArray(SiteGenerator.class, SITE_OFFSET,
+          offset);
    }
 
    protected final void loadSettings() {
@@ -513,6 +523,11 @@ public class SiteGenerator extends MMFrame implements ParentPlateGUI {
                SITE_SPACING_Y, "200"));
       overlapField_.setText(app_.profile().getString(SiteGenerator.class,
                SITE_OVERLAP, "10"));
+      Double[] offset = app_.profile().getDoubleArray(SiteGenerator.class,
+              SITE_OFFSET, new Double[] {Double.NaN, Double.NaN});
+      saveCalibration_ = Double.isFinite(offset[0]) && Double.isFinite(offset[1]);//If the offset appears to be valid numbers then a calibration was previously run.
+      offset_ = new Point2D.Double(offset[0], offset[1]);
+      moveStage_.setEnabled(saveCalibration_); 
    }
 
    private void setPositionList() {
@@ -695,8 +710,9 @@ public class SiteGenerator extends MMFrame implements ParentPlateGUI {
       }
    }
 
-   public void finishCalibration(Point2D.Double offset) {
+   public void finishCalibration(Point2D.Double offset, Boolean saveCalibration) {
        offset_ = offset;
+       saveCalibration_ = saveCalibration;
       regenerate();
       moveStage_.setEnabled(true);
    }
@@ -754,4 +770,9 @@ public class SiteGenerator extends MMFrame implements ParentPlateGUI {
       shouldIgnoreFormatEvent_ = false;
       platePanel_.repaint();
    }
+   
+   @Override
+    public Point2D.Double getOffset(){
+       return offset_;
+    } 
 }

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
@@ -773,6 +773,17 @@ public class SiteGenerator extends MMFrame implements ParentPlateGUI {
    
    @Override
     public Point2D.Double getOffset(){
-       return offset_;
+        if (offset_ == null){
+            return new Point2D.Double(0,0);
+        } else{
+            return offset_;
+        }
     } 
+    
+    @Override
+    public Point2D.Double applyOffset(Point2D.Double pt) {
+      Point2D.Double offset = getOffset();
+      pt.setLocation(pt.getX() + offset.getX(), pt.getY() + offset.getY());
+      return pt;
+   }
 }


### PR DESCRIPTION
This PR adds a combo box with the option to calibrate by saving an offset between plugin coordinates and real-world coordinates. This offset can be saved meaning that it remains valid as long as the physical hardware configuration is unchanged. This approach avoid resetting the device adapter's coordinates which renders other saved positions useless until the program is reset.