### PR TITLE
Allow pipeline processor Plugins to be enabled and disabled programmatically.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/data/DataManager.java
+++ b/mmstudio/src/main/java/org/micromanager/data/DataManager.java
@@ -372,13 +372,23 @@ public interface DataManager {
 
    /**
     * Return a list of the ProcessorConfigurators currently being used by the
-    * application pipeline interface. This only returns those configurators that are
-    * currently enabled; if a processor is part of the pipeline but has been disabled,
-    * then it will not be in this list.
+    * application pipeline interface. If `includeDisabled` is false this only returns those configurators that are
+    * currently enabled.
+    * @param boolean determines whether or not to include configurators that are not currently enabled.
     * @return An ordered list of ProcessorConfigurators.
     */
-   List<ProcessorConfigurator> getApplicationPipelineConfigurators();
+   List<ProcessorConfigurator> getApplicationPipelineConfigurators(boolean includeDisabled);
 
+   
+  /**
+    * Return a list of the ProcessorConfigurators currently being used by the
+    * live pipeline interface. If `includeDisabled` is false this only returns those configurators that are
+    * currently enabled.
+    * @param boolean determines whether or not to include configurators that are not currently enabled.
+    * @return An ordered list of ProcessorConfigurators.
+    */
+    List<ProcessorConfigurator> getLivePipelineConfigurators(boolean includeDisabled);
+       
    /**
     * Clear the current application pipeline, so that no on-the-fly image
     * processing is performed.
@@ -419,6 +429,39 @@ public interface DataManager {
     */
    void setApplicationPipeline(List<ProcessorPlugin> plugins);
 
+   
+    /**
+    * Checks whether or not the plugin at position `index` in the list is enabled
+    * for the application pipeline.
+    * @param index. an int determining which position in the list to check
+    * @return boolean of whether or not the plugin is enabled.
+    */
+    boolean isApplicationPipelineStepEnabled(int index);
+    
+    /**
+    * Sets whether or not the plugin at position `index` in the list is enabled
+    * for the application pipeline.
+    * @param index. an int determining which position in the list to check
+    * @param boolean of whether or not the plugin should be enabled.
+    */
+    void setApplicationPipelineStepEnabled(int index, boolean enabled);
+    
+    /**
+    * Checks whether or not the plugin at position `index` in the list is enabled
+    * for the live pipeline.
+    * @param index. an int determining which position in the list to check
+    * @return boolean of whether or not the plugin is enabled.
+    */
+    boolean isLivePipelineStepEnabled(int index);
+    
+    /**
+    * Sets whether or not the plugin at position `index` in the list is enabled
+    * for the live pipeline.
+    * @param index. an int determining which position in the list to check
+    * @param boolean of whether or not the plugin should be enabled.
+    */
+    void setLivePipelineStepEnabled(int index, boolean enabled);
+    
    /**
     * Notify the application that the state of one of the processors in the
     * pipeline has changed, and thus that entities that use the application

--- a/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataManager.java
+++ b/mmstudio/src/main/java/org/micromanager/data/internal/DefaultDataManager.java
@@ -328,9 +328,23 @@ public final class DefaultDataManager implements DataManager {
    }
 
    @Override
-   public List<ProcessorConfigurator> getApplicationPipelineConfigurators() {
-      return MMStudio.getInstance().getPipelineFrame().getPipelineConfigurators();
+   public List<ProcessorConfigurator> getApplicationPipelineConfigurators(boolean includeDisabled) {
+       if (includeDisabled) {
+        return MMStudio.getInstance().getPipelineFrame().getPipelineConfigurators();
+       } else {
+           return MMStudio.getInstance().getPipelineFrame().getEnabledPipelineConfigurators();
+       }
    }
+   
+     @Override
+    public List<ProcessorConfigurator> getLivePipelineConfigurators(boolean includeDisabled) {
+        if (includeDisabled) {
+            return MMStudio.getInstance().getPipelineFrame().getPipelineConfigurators();
+        } else {
+           return MMStudio.getInstance().getPipelineFrame().getEnabledLivePipelineConfigurators();
+        }
+    }
+    
 
    @Override
    public void clearPipeline() {
@@ -356,6 +370,26 @@ public final class DefaultDataManager implements DataManager {
          addAndConfigureProcessor(plugin);
       }
    }
+
+    @Override
+    public boolean isApplicationPipelineStepEnabled(int index) {
+        return MMStudio.getInstance().getPipelineFrame().getConfiguratorEnabled(index);
+    }
+    
+    @Override
+    public void setApplicationPipelineStepEnabled(int index, boolean enabled) {
+        MMStudio.getInstance().getPipelineFrame().setConfiguratorEnabled(index, enabled);
+    }
+    
+    @Override
+    public boolean isLivePipelineStepEnabled(int index) {
+        return MMStudio.getInstance().getPipelineFrame().getConfiguratorEnabledLive(index);
+    }
+    
+    @Override
+    public void setLivePipelineStepEnabled(int index, boolean enabled) {
+        MMStudio.getInstance().getPipelineFrame().setConfiguratorEnabledLive(index, enabled);
+    }
 
    @Override
    public void notifyPipelineChanged() {

--- a/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineFrame.java
@@ -343,7 +343,7 @@ final public class PipelineFrame extends MMFrame
     * Return a list of the currently-active configurators.
     */
    public List<ProcessorConfigurator> getPipelineConfigurators() {
-      return getTableModel().getPipelineConfigurators();
+      return getTableModel().getEnabledConfigurators(false);
    }
 
    /**

--- a/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineFrame.java
@@ -370,11 +370,17 @@ final public class PipelineFrame extends MMFrame
         return convertWrappersToConfigurators(configs);
    }
    
+    /*
+    * Set whether or not a configurator is enabled.
+    */
    public void setConfiguratorEnabled(int row, boolean enabled) {
        int column = getTableModel().ENABLED_COLUMN;
        getTableModel().setValueAt(enabled, row, column);
    }
    
+   /*
+   * Set whether or not a configurator is enabled for live mode
+   */
     public void setConfiguratorEnabledLive(int row, boolean enabled) {
        int column = getTableModel().ENABLED_LIVE_COLUMN;
        getTableModel().setValueAt(enabled, row, column);

--- a/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineFrame.java
@@ -348,10 +348,10 @@ final public class PipelineFrame extends MMFrame
    }
    
    /**
-    * Return a list of the currently-active configurators.
+    * Return a list of the configurators.
     */
    public List<ProcessorConfigurator> getPipelineConfigurators() {
-      return getTableModel().getEnabledConfigurators(false);
+      return convertWrappersToConfigurators(getTableModel().getPipelineConfigurators());
    }
 
    /**

--- a/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineFrame.java
@@ -353,6 +353,34 @@ final public class PipelineFrame extends MMFrame
    public List<ProcessorConfigurator> getPipelineConfigurators() {
       return convertWrappersToConfigurators(getTableModel().getPipelineConfigurators());
    }
+   
+    /**
+    * Return a list of the enabled configurators.
+    */
+   public List<ProcessorConfigurator> getEnabledPipelineConfigurators() {
+        List<ConfiguratorWrapper> configs = getTableModel().getEnabledConfigurators(false);
+        return convertWrappersToConfigurators(configs);
+   }
+   
+    /**
+    * Return a list of the live-mode enabled configurators.
+    */
+   public List<ProcessorConfigurator> getEnabledLivePipelineConfigurators() {
+        List<ConfiguratorWrapper> configs = getTableModel().getEnabledConfigurators(true);
+        return convertWrappersToConfigurators(configs);
+   }
+   
+   public void setConfiguratorEnabled(int row, boolean enabled) {
+       int column = getTableModel().ENABLED_COLUMN;
+       getTableModel().setValueAt(enabled, row, column);
+   }
+   
+    public void setConfiguratorEnabledLive(int row, boolean enabled) {
+       int column = getTableModel().ENABLED_LIVE_COLUMN;
+       getTableModel().setValueAt(enabled, row, column);
+    }
+   
+   
 
    /**
     * Clear the pipeline table.

--- a/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineFrame.java
@@ -339,6 +339,14 @@ final public class PipelineFrame extends MMFrame
       return getTableModel().getPipelineFactories(true);
    }
 
+   private List<ProcessorConfigurator> convertWrappersToConfigurators(List<ConfiguratorWrapper> configs){
+        ArrayList<ProcessorConfigurator> result = new ArrayList<ProcessorConfigurator>();
+        for (ConfiguratorWrapper config : configs) {
+            result.add(config.getConfigurator());
+        }
+        return result; 
+   }
+   
    /**
     * Return a list of the currently-active configurators.
     */

--- a/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineFrame.java
@@ -386,7 +386,21 @@ final public class PipelineFrame extends MMFrame
        getTableModel().setValueAt(enabled, row, column);
     }
    
+    /*
+    * Get whether or not a configurator is enabled.
+    */
+   public boolean getConfiguratorEnabled(int row) {
+       int column = getTableModel().ENABLED_COLUMN;
+       return (boolean) getTableModel().getValueAt(row, column);
+   }
    
+   /*
+   * Get whether or not a configurator is enabled for live mode
+   */
+    public boolean getConfiguratorEnabledLive(int row) {
+       int column = getTableModel().ENABLED_LIVE_COLUMN;
+       return (boolean) getTableModel().getValueAt(row, column);
+    }
 
    /**
     * Clear the pipeline table.

--- a/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineTableModel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineTableModel.java
@@ -97,19 +97,21 @@ public final class PipelineTableModel extends AbstractTableModel {
    }
 
    /**
-    * Provide a list of configurators for all enabled processors.
+    * Provide a list of configurators for all processors.
     */
    public List<ProcessorConfigurator> getPipelineConfigurators() {
       ArrayList<ProcessorConfigurator> result = new ArrayList<ProcessorConfigurator>();
       for (ConfiguratorWrapper config : pipelineConfigs_) {
-         if (config.getIsEnabled()) {
             result.add(config.getConfigurator());
-         }
       }
       return result;
    }
 
-   public ArrayList<ConfiguratorWrapper> getEnabledConfigurators(boolean isLiveMode) {
+   /*
+   Provide a list of all enabled configurators. If the argument is true then only configurators
+   that are enabled for live mode are returned.
+   */
+   public List<ConfiguratorWrapper> getEnabledConfigurators(boolean isLiveMode) {
       ArrayList<ConfiguratorWrapper> result = new ArrayList<ConfiguratorWrapper>();
       for (ConfiguratorWrapper config : pipelineConfigs_) {
          if ((isLiveMode && config.getIsEnabledInLive()) ||

--- a/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineTableModel.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/pipelineinterface/PipelineTableModel.java
@@ -99,12 +99,8 @@ public final class PipelineTableModel extends AbstractTableModel {
    /**
     * Provide a list of configurators for all processors.
     */
-   public List<ProcessorConfigurator> getPipelineConfigurators() {
-      ArrayList<ProcessorConfigurator> result = new ArrayList<ProcessorConfigurator>();
-      for (ConfiguratorWrapper config : pipelineConfigs_) {
-            result.add(config.getConfigurator());
-      }
-      return result;
+   public List<ConfiguratorWrapper> getPipelineConfigurators() {
+      return pipelineConfigs_;
    }
 
    /*


### PR DESCRIPTION
This PR makes a few minor changes to the public methods of the pipelineFrame, which is accessible through the API.

`getPipelineConfigurators` will now return all configurators even if they are not enabled.

I have also added two methods to return only configurators that are enabled.

I have also added methods that allow the user to set the enabled status of a configurator based on it's position in the pipelineFrame.

See issues #29 and #30