### PR TITLE
Overlay improvements.

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/display/overlay/internal/overlays/PatternOverlay.java
+++ b/mmstudio/src/main/java/org/micromanager/display/overlay/internal/overlays/PatternOverlay.java
@@ -51,6 +51,8 @@ import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSlider;
+import javax.swing.JFormattedTextField;
+import java.text.NumberFormat;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import net.miginfocom.layout.CC;
@@ -337,6 +339,8 @@ public class PatternOverlay extends AbstractOverlay {
    private JPanel configUI_;
    private JComboBox patternTypeComboBox_;
    private JSlider patternSizeSlider_;
+   private JFormattedTextField patternSizeTextBox_;
+   private JLabel patternSizeLabel_;
    private JComboBox colorComboBox_;
    private JCheckBox showSizeCheckBox_;
 
@@ -424,6 +428,7 @@ public class PatternOverlay extends AbstractOverlay {
       try {
          patternTypeComboBox_.setSelectedItem(patternType_);
          patternSizeSlider_.setValue(patternSize_);
+         patternSizeTextBox_.setValue(patternSize_);
          colorComboBox_.setSelectedItem(color_);
          showSizeCheckBox_.setSelected(showSize_);
       }
@@ -464,7 +469,19 @@ public class PatternOverlay extends AbstractOverlay {
                return;
             }
             patternSize_ = patternSizeSlider_.getValue();
+            patternSizeTextBox_.setValue(patternSize_);
             fireOverlayConfigurationChanged();
+         }
+      });
+      
+      NumberFormat patternSizeTextFormat = NumberFormat.getInstance();
+      patternSizeTextBox_ = new JFormattedTextField(patternSizeTextFormat);
+      patternSizeTextBox_.setColumns(2);
+      patternSizeLabel_ = new JLabel("%");
+      patternSizeTextBox_.addActionListener(new ActionListener() {
+         public void actionPerformed(ActionEvent e) {
+           patternSize_ = ((Long) patternSizeTextBox_.getValue()).intValue();
+           patternSizeSlider_.setValue(patternSize_);
          }
       });
 
@@ -487,6 +504,8 @@ public class PatternOverlay extends AbstractOverlay {
 
       configUI_.add(new JLabel("Pattern Size:"), new CC().split().gapAfter("rel"));
       configUI_.add(patternSizeSlider_, new CC().gapAfter("unrel"));
+      configUI_.add(patternSizeTextBox_, new CC().gapAfter("rel"));
+      configUI_.add(patternSizeLabel_, new CC().wrap());
       configUI_.add(showSizeCheckBox_, new CC().wrap());
    }
 }

--- a/mmstudio/src/main/java/org/micromanager/display/overlay/internal/overlays/PatternOverlay.java
+++ b/mmstudio/src/main/java/org/micromanager/display/overlay/internal/overlays/PatternOverlay.java
@@ -198,7 +198,7 @@ public class PatternOverlay extends AbstractOverlay {
       CIRCLE("Circle") {
          @Override
          void draw(Graphics2D g, int patternSize, float width, float height) {
-            float r = 0.5f * patternSize * Math.min(width, height) / 100.0f;
+            float r = 0.5f * patternSize * Math.max(width, height) / 100.0f * (float)Math.sqrt(2);
             g.draw(new Ellipse2D.Float(0.5f * width - r, 0.5f * height - r,
                   2.0f * r, 2.0f * r));
          }
@@ -207,7 +207,7 @@ public class PatternOverlay extends AbstractOverlay {
          String getSizeString(int patternSize, double umPerImagePixel,
                float width, float height)
          {
-            float dImgPx = patternSize * Math.min(width, height) / 100.0f;
+            float dImgPx = patternSize * Math.max(width, height) / 100.0f * (float)Math.sqrt(2);
             if (Double.isNaN(umPerImagePixel)) {
                return String.format("Circle Diameter: %d px",
                      (int) Math.round(dImgPx));


### PR DESCRIPTION
This PR does two things:

1: adds a text field that allows the user to specify overlay size numerically.

2: Increases the size of the circle overlay so that its radius can reach the furthest corner of the image. Before the circle overlay could only be expanded to where it could reach the nearest edge of the image.