### PR TITLE
Read-only profiles

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/ProfileSelectionUIController.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/ProfileSelectionUIController.java
@@ -19,7 +19,7 @@ import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.JComboBox;
-import javax.swing.JCheckBox;
+import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JComponent;
 import javax.swing.JFrame;
 import javax.swing.JMenuItem;
@@ -48,7 +48,6 @@ public final class ProfileSelectionUIController
    private ChangeListener profileIndexListener_;
 
    private final JPanel panel_;
-   private final JCheckBox readOnlyCheckBox_ = new JCheckBox();
    private final JComboBox profileComboBox_ = new JComboBox();
    private final PopupButton gearButton_;
 
@@ -60,7 +59,9 @@ public final class ProfileSelectionUIController
    private final JMenuItem gearMenuRenameProfileItem_ =
          new JMenuItem("Rename Profile...");
    private final JMenuItem gearMenuDeleteProfileItem_ =
-         new JMenuItem("Delete User Profile...");
+         new JMenuItem("Delete User Profile..."); 
+   private final JCheckBoxMenuItem gearMenuReadOnlyCheckBox_ = 
+         new JCheckBoxMenuItem("Profile Read Only");
 
    private static class ProfileComboItem {
       final UUID uuid_;
@@ -85,10 +86,9 @@ public final class ProfileSelectionUIController
 
       ret.profileComboBox_.addActionListener(ret);
       ret.gearButton_.addPopupButtonListener(ret);
-      ret.readOnlyCheckBox_.addActionListener(ret);
       for (JMenuItem item : ImmutableList.of(ret.gearMenuNewProfileItem_,
             ret.gearMenuDuplicateProfileItem_, ret.gearMenuRenameProfileItem_,
-            ret.gearMenuDeleteProfileItem_)) {
+            ret.gearMenuDeleteProfileItem_, ret.gearMenuReadOnlyCheckBox_)) {
          item.addActionListener(ret);
       }
 
@@ -119,6 +119,7 @@ public final class ProfileSelectionUIController
       gearMenu_.add(gearMenuDuplicateProfileItem_);
       gearMenu_.add(gearMenuRenameProfileItem_);
       gearMenu_.add(gearMenuDeleteProfileItem_);
+      gearMenu_.add(gearMenuReadOnlyCheckBox_);
 
       gearButton_ = PopupButton.create(
             IconLoader.getIcon("/org/micromanager/icons/gear.png"),
@@ -129,13 +130,9 @@ public final class ProfileSelectionUIController
             new LC().fillX().insets("0").gridGap("0", "0")));
       panel_.add(profileComboBox_, new CC().growX().pushX());
       panel_.add(gearButton_, new CC().width("pref!").height("pref!"));
-      panel_.add(readOnlyCheckBox_);
-
       profileComboBox_.setToolTipText(
             "<html>Select the user profile for this session.<br />" +
                   "Settings and preferences are saved in each user profile.</html>");
-      readOnlyCheckBox_.setToolTipText(
-            "Prevent changes from being saved.");
       gearButton_.setToolTipText(
             "Manage user profiles");
    }
@@ -216,7 +213,7 @@ public final class ProfileSelectionUIController
       else if (event.getSource() == gearMenuDeleteProfileItem_) {
          handleDeleteProfile();
       }
-      else if (event.getSource() == readOnlyCheckBox_) {
+      else if (event.getSource() == gearMenuReadOnlyCheckBox_) {
          handleReadOnlyAction();
       }
    }
@@ -225,7 +222,7 @@ public final class ProfileSelectionUIController
       UUID uuid = admin_.getUUIDOfCurrentProfile();
       if (uuid != null) {
           try {
-            admin_.setProfileReadOnly(readOnlyCheckBox_.isSelected());
+            admin_.setProfileReadOnly(gearMenuReadOnlyCheckBox_.isSelected());
           } catch (IOException e) {}
       }
    }
@@ -235,7 +232,7 @@ public final class ProfileSelectionUIController
          UUID uuid = getSelectedProfileUUID();
          if (uuid != null) {
             admin_.setCurrentUserProfile(uuid);
-            readOnlyCheckBox_.setSelected(admin_.isProfileReadOnly());
+            gearMenuReadOnlyCheckBox_.setSelected(admin_.isProfileReadOnly());
          }
       }
       catch (IOException e) {

--- a/mmstudio/src/main/java/org/micromanager/internal/dialogs/ProfileSelectionUIController.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/dialogs/ProfileSelectionUIController.java
@@ -19,6 +19,7 @@ import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.JComboBox;
+import javax.swing.JCheckBox;
 import javax.swing.JComponent;
 import javax.swing.JFrame;
 import javax.swing.JMenuItem;
@@ -47,6 +48,7 @@ public final class ProfileSelectionUIController
    private ChangeListener profileIndexListener_;
 
    private final JPanel panel_;
+   private final JCheckBox readOnlyCheckBox_ = new JCheckBox();
    private final JComboBox profileComboBox_ = new JComboBox();
    private final PopupButton gearButton_;
 
@@ -83,6 +85,7 @@ public final class ProfileSelectionUIController
 
       ret.profileComboBox_.addActionListener(ret);
       ret.gearButton_.addPopupButtonListener(ret);
+      ret.readOnlyCheckBox_.addActionListener(ret);
       for (JMenuItem item : ImmutableList.of(ret.gearMenuNewProfileItem_,
             ret.gearMenuDuplicateProfileItem_, ret.gearMenuRenameProfileItem_,
             ret.gearMenuDeleteProfileItem_)) {
@@ -126,10 +129,13 @@ public final class ProfileSelectionUIController
             new LC().fillX().insets("0").gridGap("0", "0")));
       panel_.add(profileComboBox_, new CC().growX().pushX());
       panel_.add(gearButton_, new CC().width("pref!").height("pref!"));
+      panel_.add(readOnlyCheckBox_);
 
       profileComboBox_.setToolTipText(
             "<html>Select the user profile for this session.<br />" +
                   "Settings and preferences are saved in each user profile.</html>");
+      readOnlyCheckBox_.setToolTipText(
+            "Prevent changes from being saved.");
       gearButton_.setToolTipText(
             "Manage user profiles");
    }
@@ -210,13 +216,26 @@ public final class ProfileSelectionUIController
       else if (event.getSource() == gearMenuDeleteProfileItem_) {
          handleDeleteProfile();
       }
+      else if (event.getSource() == readOnlyCheckBox_) {
+         handleReadOnlyAction();
+      }
    }
 
+   private void handleReadOnlyAction(){
+      UUID uuid = admin_.getUUIDOfCurrentProfile();
+      if (uuid != null) {
+          try {
+            admin_.setProfileReadOnly(readOnlyCheckBox_.isSelected());
+          } catch (IOException e) {}
+      }
+   }
+   
    private void handleProfileSelection() {
       try {
          UUID uuid = getSelectedProfileUUID();
          if (uuid != null) {
             admin_.setCurrentUserProfile(uuid);
+            readOnlyCheckBox_.setSelected(admin_.isProfileReadOnly());
          }
       }
       catch (IOException e) {

--- a/mmstudio/src/main/java/org/micromanager/profile/internal/UserProfileAdmin.java
+++ b/mmstudio/src/main/java/org/micromanager/profile/internal/UserProfileAdmin.java
@@ -128,19 +128,18 @@ public final class UserProfileAdmin {
    }
 
    public boolean isReadOnlyMode() {
-      if (writeLock_ == null) {
-          return true;
+      return writeLock_ == null;
+   }
+   
+   public boolean isProfileReadOnly() {
+      UserProfile profile;
+      try {
+         profile = getNonSavingProfile(getUUIDOfCurrentProfile());
       }
-      else {
-         UserProfile profile;
-         try {
-              profile = getNonSavingProfile(getUUIDOfCurrentProfile());
-         }
-         catch (IOException e) {
-              return true;
-         }
-         return profile.getSettings(UserProfileAdmin.class).getBoolean(READ_ONLY, false);
+      catch (IOException e) {
+         return true;
       }
+      return profile.getSettings(UserProfileAdmin.class).getBoolean(READ_ONLY, false);
    }
 
    /**
@@ -482,7 +481,7 @@ public final class UserProfileAdmin {
    }
 
    private void writeFile(String filename, Profile profile) throws IOException {
-      if (isReadOnlyMode()) {
+      if (isReadOnlyMode() || isProfileReadOnly()) {
          virtualProfiles_.put(filename, profile);
          return;
       }


### PR DESCRIPTION
This pull request adds a `read-only` option to user profiles. The read only property can be toggled using the "Gear" menu in the opening splash screen.

When a profile is set to be read-only changes to its settings will be saved in RAM only while that session of micromanager is running. Nothing is written to file, so restarting Micromanager will reset the profile back to how it was when it was originally set to be read-only.