### PR TITLE
UI fixes

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MainFrame.java
@@ -163,8 +163,6 @@ public final class MainFrame extends MMFrame {
       DropTarget dropTarget = new DropTarget(this, new DragDropUtil(studio_));
 
       setExitStrategy(OptionsDlg.getShouldCloseOnExit());
-      super.setIconImage(Toolkit.getDefaultToolkit().getImage(
-               getClass().getResource("/org/micromanager/icons/microscope.gif")));
 
       super.setJMenuBar(MMMenuBar.createMenuBar(studio_));
 

--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
@@ -68,11 +68,10 @@ import org.micromanager.internal.utils.EventBusExceptionLogger;
 import org.micromanager.internal.utils.FileDialogs;
 import org.micromanager.internal.utils.FileDialogs.FileType;
 import org.micromanager.internal.utils.GUIUtils;
-import org.micromanager.internal.utils.MMDialog;
+import org.micromanager.internal.utils.MMFrame;
 import org.micromanager.internal.utils.ReportingUtils;
 
-
-public final class PositionListDlg extends MMDialog implements MouseListener, ChangeListener {
+public final class PositionListDlg extends MMFrame implements MouseListener, ChangeListener {
    private static final long serialVersionUID = 1L;
    private String posListDir_;
    private File curFile_;
@@ -916,10 +915,10 @@ public final class PositionListDlg extends MMDialog implements MouseListener, Ch
       double [] x1;
       double [] y1;
       String deviceName;
-      MMDialog d;
+      MMFrame d;
       Thread otherThread;
 
-      public void setPara(Thread calThread, MMDialog d, String deviceName, double [] x1, double [] y1) {
+      public void setPara(Thread calThread, MMFrame d, String deviceName, double [] x1, double [] y1) {
          this.otherThread = calThread;
          this.d = d;
          this.deviceName = deviceName;
@@ -1036,10 +1035,10 @@ public final class PositionListDlg extends MMDialog implements MouseListener, Ch
       double [] x1;
       double [] y1;
       String deviceName;
-      MMDialog d;
+      MMFrame d;
       Thread stopThread;
 
-      public void setPara(Thread stopThread, MMDialog d, String deviceName, double [] x1, double [] y1) {
+      public void setPara(Thread stopThread, MMFrame d, String deviceName, double [] x1, double [] y1) {
          this.stopThread = stopThread;
          this.d = d;
          this.deviceName = deviceName;
@@ -1108,9 +1107,9 @@ public final class PositionListDlg extends MMDialog implements MouseListener, Ch
    } // End CalThread class
 
    class BackThread extends Thread {
-      MMDialog d;
+      MMFrame d;
 
-      public void setPara(MMDialog d) {
+      public void setPara(MMFrame d) {
          this.d = d;
       }     
       @Override

--- a/mmstudio/src/main/java/org/micromanager/internal/utils/MMFrame.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/utils/MMFrame.java
@@ -52,12 +52,16 @@ public class MMFrame extends JFrame {
       super();
       profileKey_ = "";
       setupMenus();
+      super.setIconImage(Toolkit.getDefaultToolkit().getImage(
+        getClass().getResource("/org/micromanager/icons/microscope.gif")));
    }
 
    public MMFrame(String profileKeyForSavingBounds) {
       super();
       profileKey_ = profileKeyForSavingBounds;
       setupMenus();
+      super.setIconImage(Toolkit.getDefaultToolkit().getImage(
+        getClass().getResource("/org/micromanager/icons/microscope.gif")));
    }
 
    /**
@@ -71,6 +75,8 @@ public class MMFrame extends JFrame {
       if (usesMMMenus) {
          setupMenus();
       }
+      super.setIconImage(Toolkit.getDefaultToolkit().getImage(
+        getClass().getResource("/org/micromanager/icons/microscope.gif")));
    }
 
    /**


### PR DESCRIPTION
This PR fixes a few things about the UI that have been bugging me:

1: Since using Micromanager usually involves many different windows it is annoying to have to go and activate each one separately when switching between another application. Now, when the user activates an MMFrame after using a different application all other MMFrames will be brought to the front.

2: I often find myself using the StagePositionListDialog. However it has some annoying behaviour due to being an MMDialog rather than MMFrame (e.g. it doesn't appear in the windows task bar). The StagePositionListDialog is now an instance of MMFrame.

3: All MMFrames now have the MicroManager icon rather than the generic Java icon.