### PR TITLE
add plugins and autofocus to the matlab path

### DIFF
--- a/bindist/any-Windows/StartMMStudio.m
+++ b/bindist/any-Windows/StartMMStudio.m
@@ -396,6 +396,19 @@ function mmJars = GetMMJars(pathToMM)
       jarName = fullfile(jarPath, jarFile.name);
       k = k + 1; mmJars{k} = jarName;
    end
+   
+   jarPath = fullfile(pathToMM, 'mmplugins');
+   for jarFile = dir(fullfile(jarPath, '*.jar'))'
+      jarName = fullfile(jarPath, jarFile.name);
+      k = k + 1; mmJars{k} = jarName;
+   end
+   
+   jarPath = fullfile(pathToMM, 'mmautofocus');
+   for jarFile = dir(fullfile(jarPath, '*.jar'))'
+      jarName = fullfile(jarPath, jarFile.name);
+      k = k + 1; mmJars{k} = jarName;
+   end
+   
 
    mmJars = mmJars';
 end


### PR DESCRIPTION
Currently the StartMMStudio matlab script only add the core .jars to matlabs class path. This means that if the user uses a method that returns an autofocus or any other form of plugin matlab will return a null value without throwing an error. e.g.:  mm.getAutofocusManager().getAutofocusMethod().

This pr adds these additional files to the matlab class path