### PR TITLE
fix SutterLambda2 visual studio project file.

### DIFF
--- a/DeviceAdapters/SutterLambda2/SutterLambda2.vcxproj
+++ b/DeviceAdapters/SutterLambda2/SutterLambda2.vcxproj
@@ -168,7 +168,9 @@
     <ClCompile Include="SutterLambda2.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="SutterLambda2.h" />
+    <ClInclude Include="SutterHub.h" />
+    <ClInclude Include="SutterShutter.h" />
+    <ClInclude Include="SutterWheel.h" />
     <ClInclude Include="WheelBase.h" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
During integration of the SutterLambda2 adapter the headers files were reorganized but the project file doesn't appear to have been updated. This PR just updates the project file to accurately reflect the source code.