### PR TITLE
Add support for the Axio Imager.A2

### DIFF
--- a/DeviceAdapters/ZeissCAN29/ZeissHub.cpp
+++ b/DeviceAdapters/ZeissCAN29/ZeissHub.cpp
@@ -114,6 +114,27 @@ int ZeissHub::Initialize(MM::Device& device, MM::Core& core)
 {
    if (!portInitialized_)
       return ERR_PORT_NOT_OPEN;
+      const int commandLength = 5;
+   
+   // Send a command to initialize an Axio Imager.A2. A bit of a hack, but the microscope responds incorrectly without it.
+   unsigned char command[16];
+   command[0] = 0x10;
+   command[1] = 0x02;
+   command[2] = 0x1B;
+   command[3] = 0x10;
+   command[4] = 0x10;
+   command[5] = 0x05;
+   command[6] = 0x19;
+   command[7] = 0xA1;
+   command[8] = 0x10;
+   command[9] = 0x10;
+   command[10] = 0x01;
+   command[11] = 0x1D;
+   command[12] = 0x00;
+   command[13] = 0x02;
+   command[14] = 0x10;
+   command[15] = 0x03;
+   core.WriteToSerial(&device, port_.c_str(), &(command[0]), (unsigned long)16);
    
    std::ostringstream os;
    os << "Initializing Hub";


### PR DESCRIPTION
First, I'd like to say that Micro-Manager existence is astounding and a life saver in a market of criminally overpriced proprietary scientific software.

I've been using Micro-Manager with an Axio Imager.A2 and I've had some issues getting it working properly .

If I turn the microscope on and try to connect with micro-manager, everything appears to connect, but the microscope won't respond to any commands and this causes Micro-Manager to hang.

If I turn the microscope on, connect to it through Zeiss MTB, and then close Zeiss MTB and open Micro-Manager, the microscope works just fine.

I don't have any documentation for Zeiss's serial protocol, but I used a serial port sniffer to identify the command Zeiss MTB sends to close the reflected light shutter.

I have found that sending Zeiss MTB's proper command to toggle the shuttle to the microscope before Micro-Manager initializes the device causes it to function properly. It feels like such a hack, and I don't know why, but it works.

I am but a peasant with a single microscope so I can't check to see if this effects microscopes besides the Imager.A2, but it shouldn't hurt because the Rx buffer is cleared after this command is sent.

I don't know whether it's appropriate to add this in the code, but I thought I'd let you know about it.

Thanks!
Russell

Also, since the Imager.A2 doesn't have any CAN bus ports, is there any possibility of controlling a Colibri through USB?