### PR TITLE
Property browser double update

### DIFF
--- a/bindist/any-Windows/StartMMStudio.m
+++ b/bindist/any-Windows/StartMMStudio.m
@@ -68,7 +68,7 @@ function S = StartMMStudio(varargin)
 
    flag = '';  % '-setup', '-undosetup', or '' (indicating 'run' mode)
    pathToMM = '';
-   autoStartProfile = []
+   autoStartProfile = [];
    argsOk = true;
 
    for k = 1:nargin

--- a/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/MMStudio.java
@@ -1097,7 +1097,7 @@ public final class MMStudio implements Studio, CompatibilityInterface, PositionL
             calibrationListDlg_.refreshCalibrations();
          }
          if (propertyBrowser_ != null) {
-            propertyBrowser_.refresh();
+            propertyBrowser_.refresh(fromCache);
          }
 
          ReportingUtils.logMessage("Finished updating GUI");

--- a/mmstudio/src/main/java/org/micromanager/internal/PropertyEditor.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/PropertyEditor.java
@@ -144,7 +144,7 @@ public final class PropertyEditor extends MMFrame {
       
       refreshButton.setFont(defaultFont);
       refreshButton.addActionListener((ActionEvent e) -> {
-         refresh();
+         refresh(false);
       });
       add(refreshButton, "width 100!, center, wrap");
 
@@ -155,10 +155,10 @@ public final class PropertyEditor extends MMFrame {
       add(scrollPane_, "span, grow, push, wrap");
    }
 
-   protected void refresh() {
+   protected void refresh(boolean fromCache) {
       data_.setFlags(flags_);
       data_.setShowUnused(true);
-      data_.refresh(false);
+      data_.refresh(fromCache);
    }
 
    @Subscribe
@@ -166,7 +166,7 @@ public final class PropertyEditor extends MMFrame {
       // avoid re-executing a refresh because of callbacks while we are
       // updating
       if (!data_.updating()) {
-         refresh();
+         refresh(false);
       }
    }
 


### PR DESCRIPTION
This PR fixes a minor issue where setting a property value using the PropertyBrowser causes all properties to be updated from the device adapters twice. This was essentially happening because calling `MMStudio.updateGui` with the `fromCache` argument set as `true` was actually causing the `PropertyEditor` class to update from the hardware rather than from the cache.

A minor change also included in this PR is that the `StartMMStudio.m` matlab script now has some output silenced that was accidentally left unsilenced in one of my earlier PR's.