### PR TITLE
Fix constant deselection of positions

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/positionlist/PositionListDlg.java
@@ -803,12 +803,8 @@ public final class PositionListDlg extends MMFrame implements MouseListener, Cha
       positionModel_.setCurrentMSP(curMsp_);
 
       PositionTableModel ptm = (PositionTableModel) posTable_.getModel();
-      int selectedRow = posTable_.getSelectedRow();
       ptm.fireTableCellUpdated(0, 1);
       ptm.fireTableCellUpdated(0, 0);
-      if (selectedRow > 0)
-         posTable_.setRowSelectionInterval(selectedRow, selectedRow);
-      
       posTable_.revalidate();
       axisTable_.revalidate();
    }


### PR DESCRIPTION
This fixes an annoying issue where any time that the position reported by an XY stage changes by any amount the PositionList dialog will deselect any range of positions that you had selected. In the case of some XY stages this happens randomly all the time making it impossible to select a range of positions.