### PR TITLE
PicardStage: homing for Z stage and consistent busy behaviour

### DIFF
--- a/DeviceAdapters/PicardStage/PicardStage.cpp
+++ b/DeviceAdapters/PicardStage/PicardStage.cpp
@@ -545,8 +545,6 @@ CPiStage::CPiStage()
 	CreateProperty(g_Keyword_Min, FIXED_TO_STRING(MOTOR_LOWER_LIMIT), MM::Integer, false, NULL, true);
 	CreateProperty(g_Keyword_Max, FIXED_TO_STRING(MOTOR_UPPER_LIMIT), MM::Integer, false, NULL, true);
 
-	CreateProperty("GoHome", "0", MM::Integer, false, new CPropertyAction(this, &CPiStage::OnGoHomeProp), false);
-
 	SetErrorText(1, "Could not initialize motor (Z stage)");
 }
 
@@ -565,60 +563,19 @@ int CPiStage::OnVelocity(MM::PropertyBase* pProp, MM::ActionType eAct)
 	return OnVelocityGeneric(pProp, eAct, handle_, velocity_, &piGetMotorVelocity, &piSetMotorVelocity);
 }
 
-int CPiStage::OnGoHomeProp(MM::PropertyBase* pProp, MM::ActionType eAct)
-{
-	if(handle_ == NULL)
-		return (eAct == MM::BeforeGet ? DEVICE_OK : DEVICE_ERR);
-
-	long lval = -1;
-	if(!(pProp->Get(lval)))
-		return DEVICE_ERR;
-
-	switch(eAct)
-	{
-	case MM::AfterSet:
-		{
-			if(lval == 1)
-			{
-				return InterpretPiUsbError(piHomeMotor(10, handle_));
-			}
-			else
-			{
-				pProp->Set((long)0);
-				return DEVICE_OK;
-			}
-		};
-	case MM::BeforeGet:
-		{
-			if(lval == 1)
-			{
-				BOOL home = FALSE;
-				if(piGetMotorHomeStatus(&home, handle_) != PI_NO_ERROR)
-					return DEVICE_ERR;
-
-				pProp->Set((long)(home ? 0 : 1));
-			}
-
-			return DEVICE_OK;
-		};
-	default:
-		return DEVICE_OK; // Don't care.
-	};
-}
-
 bool CPiStage::Busy()
 {
 	if(handle_ == NULL)
 		return false;
 
-	long homing = 0;
-	if(GetProperty("GoHome", homing) == DEVICE_OK && homing == 1)
+	if(homing_)
 	{
 		BOOL home = FALSE;
 		if(piGetMotorHomeStatus(&home, handle_) != PI_NO_ERROR)
 			return false;
 
-		return !home;
+		homing_ = !home;
+		return homing_;
 	}
 
 	BOOL moving;
@@ -740,6 +697,21 @@ int CPiStage::GetPositionSteps(long& steps)
 		steps = static_cast<long>(position);
 
 	return InterpretPiUsbError(pi_error);
+}
+
+int CPiStage::Home()
+{
+	if (handle_ == NULL)
+		return DEVICE_NOT_CONNECTED;
+
+	int error;
+
+	if ((error = piHomeMotor(velocity_, handle_) != PI_NO_ERROR)
+		return InterpretPiUsbError(error);
+
+	homing_ = true;
+
+	return DEVICE_OK;
 }
 
 int CPiStage::SetOrigin()
@@ -885,6 +857,21 @@ bool CPiXYStage::Busy()
 {
 	if(handleX_ == NULL || handleY_ == NULL)
 		return false;
+
+	if (homing_) {
+		BOOL homeX = FALSE;
+		BOOL homeY = FALSE;
+
+		if (piGetMotorHomeStatus(&homeX, handleX_) != PI_NO_ERROR)
+			return false;
+	  
+		if (piGetMotorHomeStatus(&homeY, handleY_) != PI_NO_ERROR)
+			return false;
+
+		homing_ = ! (homeX && homeY);
+
+		return homing_;
+	}
 
 	BOOL movingX = FALSE, movingY = FALSE;
 
@@ -1040,6 +1027,8 @@ int CPiXYStage::Home()
 
 	if((error = piHomeMotor(velocityY_, handleY_)) != PI_NO_ERROR)
 		return InterpretPiUsbError(error);
+
+	homing_ = true;
 
 	return DEVICE_OK;
 }

--- a/DeviceAdapters/PicardStage/PicardStage.h
+++ b/DeviceAdapters/PicardStage/PicardStage.h
@@ -82,6 +82,7 @@ public:
 	int GetPositionUm(double& pos);
 	int SetPositionSteps(long steps);
 	int GetPositionSteps(long& steps);
+	int Home();
 	int SetOrigin();
 	int GetLimits(double& lower, double& upper);
 	int GetStepLimits(long& lower, long& upper);
@@ -93,11 +94,11 @@ public:
 private:
 	int OnSerialNumber(MM::PropertyBase* pProp, MM::ActionType eAct);
 	int OnVelocity(MM::PropertyBase* pProp, MM::ActionType eAct);
-	int OnGoHomeProp(MM::PropertyBase* pProp, MM::ActionType eAct);
 
 	int serial_;
 	int velocity_;
 	void *handle_;
+	bool homing_;
 };
 
 //////////////////////////////////////////////////////////////////////////////
@@ -142,6 +143,7 @@ private:
 	int serialX_, serialY_;
 	int velocityX_, velocityY_;
 	void *handleX_, *handleY_;
+	bool homing_;
 };
 
 #endif //_PICARDSTAGE_H_


### PR DESCRIPTION
Hello,

I slightly modified the PicardStage DeviceAdapter so that the CMMCore.home() function can be used to home the Z stage, with a behaviour identical to the XY stage.
I also changed the busy() function of the XY stage so that it is now considered busy when the stage is homing (thus having a behaviour consistent with the Z stage).

I compiled it and tested it successfully on my machine.

Best regards,
François Marelli