### PR TITLE
Moved ZMQServer to org.micromanager.internal

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/zmq/ZMQAcquisitionHookClient.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/zmq/ZMQAcquisitionHookClient.java
@@ -1,4 +1,4 @@
-package org.micromanager.magellan.api.zmq;
+package org.micromanager.internal.zmq;
 
 import org.json.JSONObject;
 import org.micromanager.magellan.acq.AcquisitionEvent;

--- a/mmstudio/src/main/java/org/micromanager/internal/zmq/ZMQClient.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/zmq/ZMQClient.java
@@ -3,9 +3,9 @@
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
-package org.micromanager.magellan.api.zmq;
+package org.micromanager.internal.zmq;
 
-import static org.micromanager.magellan.api.zmq.ZMQSocketWrapper.context_;
+import static org.micromanager.internal.zmq.ZMQSocketWrapper.context_;
 import org.zeromq.SocketType;
 
 /**

--- a/mmstudio/src/main/java/org/micromanager/internal/zmq/ZMQServer.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/zmq/ZMQServer.java
@@ -3,7 +3,7 @@
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
-package org.micromanager.magellan.api.zmq;
+package org.micromanager.internal.zmq;
 
 import java.util.HashMap;
 import java.util.concurrent.ExecutorService;
@@ -14,7 +14,7 @@ import org.json.JSONObject;
 import org.micromanager.magellan.acq.MagellanAcquisitionsManager;
 import org.micromanager.magellan.api.MagellanAPI;
 import org.micromanager.magellan.api.MagellanAcquisitionAPI;
-import static org.micromanager.magellan.api.zmq.ZMQSocketWrapper.parseAPI;
+import static org.micromanager.internal.zmq.ZMQSocketWrapper.parseAPI;
 import org.micromanager.magellan.main.Magellan;
 import org.micromanager.magellan.misc.Log;
 import org.zeromq.SocketType;

--- a/mmstudio/src/main/java/org/micromanager/internal/zmq/ZMQSocketWrapper.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/zmq/ZMQSocketWrapper.java
@@ -1,4 +1,4 @@
-package org.micromanager.magellan.api.zmq;
+package org.micromanager.internal.zmq;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -66,7 +66,6 @@ public abstract class ZMQSocketWrapper {
       MagellanAcquisitionAPI.class,
       MagellanAPI.class,
       MagellanAcquisitionSettingsAPI.class
-      //TODO: maybe automatically read some of these from their package
    };
    
 //   private static Package[] API_PACKAGES  = new Package[]{

--- a/plugins/Magellan/src/main/java/org/micromanager/magellan/main/Magellan.java
+++ b/plugins/Magellan/src/main/java/org/micromanager/magellan/main/Magellan.java
@@ -26,7 +26,7 @@ import mmcorej.CMMCore;
 import org.micromanager.MenuPlugin;
 import org.micromanager.Studio;
 import org.micromanager.magellan.api.MagellanAPI;
-import org.micromanager.magellan.api.zmq.ZMQServer;
+import org.micromanager.internal.zmq.ZMQServer;
 import org.scijava.plugin.Plugin;
 import org.scijava.plugin.SciJavaPlugin;
 


### PR DESCRIPTION
Still starting ZMQServer from Magellan plugin loading. Where is the appropriate place to start it after its been added to tools--options?